### PR TITLE
Add snappy_parquet directory to example data script

### DIFF
--- a/example/generate_randoms.py
+++ b/example/generate_randoms.py
@@ -10,6 +10,7 @@ n = 10 ** 6
 
 os.makedirs('data/txt', exist_ok=True)
 os.makedirs('data/parquet', exist_ok=True)
+os.makedirs('data/snappy_parquet', exist_ok=True)
 os.makedirs('data/gzip_parquet', exist_ok=True)
 os.makedirs('data/binary', exist_ok=True)
 


### PR DESCRIPTION
Currently running `python generate_randoms.py` following the example instructions can result in this `FileNotFoundError` error:

```
FileNotFoundError: [Errno 2] Failed to open local file 'data/snappy_parquet/i64_normal1.snappy.parquet'. Detail: [errno 2] No such file or directory
```

This seems to be because the `data/snappy_parquet` directory is never created in the script. This has been fixed in this PR. The script runs as expected when the data folder is empty (or non-existent) after this change.