### PR TITLE
Add boolean support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ example/venv
 .idea
 *.iml
 temp
+**/.DS_Store

--- a/example/generate_randoms.py
+++ b/example/generate_randoms.py
@@ -29,6 +29,21 @@ def write_i64(arr, name):
   pq.write_table(table, f'data/parquet/i64_{name}.parquet', compression='NONE')
   pq.write_table(table, f'data/snappy_parquet/i64_{name}.snappy.parquet', compression='snappy')
 
+def write_bool8(arr, name):
+  if arr.dtype != np.int8:
+    floored = np.floor(arr).astype(np.int8)
+  else:
+    floored = arr
+  ints = [str(x) for x in floored]
+  joined = '\n'.join(ints)
+  with open(f'data/txt/bool8_{name}.txt', 'w') as f:
+    f.write(joined)
+  with open(f'data/binary/bool8_{name}.bin', 'wb') as f:
+    f.write(floored.tobytes())
+  table = pa.Table.from_pydict({'nums': floored})
+  pq.write_table(table, f'data/parquet/bool8_{name}.parquet', compression='NONE')
+  pq.write_table(table, f'data/snappy_parquet/bool8_{name}.snappy.parquet', compression='snappy')
+
 def write_f64(arr, name):
   arr = arr.astype(np.float64)
   floats = [str(x) for x in arr]
@@ -89,3 +104,5 @@ edge_case_floats[p < 0.3] = np.nan
 edge_case_floats[p < 0.2] = -np.nan  # yes, it is different
 edge_case_floats[p < 0.1] = np.NINF
 write_f64(edge_case_floats, 'edge_cases')
+
+write_bool8(np.random.randint(2, size=n), 'random')

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -5,7 +5,7 @@ use q_compress::decompressor::Decompressor;
 use q_compress::types::{DataType, NumberLike};
 use q_compress::types::float64::F64DataType;
 use q_compress::types::signed64::I64DataType;
-use q_compress::types::boolean8::BoolDataType;
+use q_compress::types::boolean::BoolDataType;
 use std::convert::TryInto;
 use std::env;
 use std::fs;

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -5,6 +5,7 @@ use q_compress::decompressor::Decompressor;
 use q_compress::types::{DataType, NumberLike};
 use q_compress::types::float64::F64DataType;
 use q_compress::types::signed64::I64DataType;
+use q_compress::types::boolean8::B8DataType;
 use std::convert::TryInto;
 use std::env;
 use std::fs;
@@ -113,6 +114,17 @@ impl DtypeHandler<f64, F64DataType> for F64Handler {
   }
 }
 
+struct B8Handler {}
+
+impl DtypeHandler<bool, B8DataType> for B8Handler {
+  fn parse_nums(bytes: &[u8]) -> Vec<bool> {
+    bytes
+      .chunks(1)
+      .map(|chunk| u8::from_le_bytes(chunk.try_into().expect("incorrect # of bytes in file")) != 0)
+      .collect()
+  }
+}
+
 fn main() {
   let args: Vec<String> = env::args().collect();
   let max_depth: u32 = if args.len() >= 2 {
@@ -149,6 +161,8 @@ fn main() {
       I64Handler::handle(&path, max_depth, &output_dir);
     } else if path_str.contains("f64") {
       F64Handler::handle(&path, max_depth, &output_dir);
+    } else if path_str.contains("bool8") {
+      B8Handler::handle(&path, max_depth, &output_dir);
     } else {
       panic!("Could not determine dtype for file {}!", path_str);
     };

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -5,7 +5,7 @@ use q_compress::decompressor::Decompressor;
 use q_compress::types::{DataType, NumberLike};
 use q_compress::types::float64::F64DataType;
 use q_compress::types::signed64::I64DataType;
-use q_compress::types::boolean8::B8DataType;
+use q_compress::types::boolean8::BoolDataType;
 use std::convert::TryInto;
 use std::env;
 use std::fs;
@@ -114,9 +114,9 @@ impl DtypeHandler<f64, F64DataType> for F64Handler {
   }
 }
 
-struct B8Handler {}
+struct BoolHandler {}
 
-impl DtypeHandler<bool, B8DataType> for B8Handler {
+impl DtypeHandler<bool, BoolDataType> for BoolHandler {
   fn parse_nums(bytes: &[u8]) -> Vec<bool> {
     bytes
       .chunks(1)
@@ -162,7 +162,7 @@ fn main() {
     } else if path_str.contains("f64") {
       F64Handler::handle(&path, max_depth, &output_dir);
     } else if path_str.contains("bool8") {
-      B8Handler::handle(&path, max_depth, &output_dir);
+      BoolHandler::handle(&path, max_depth, &output_dir);
     } else {
       panic!("Could not determine dtype for file {}!", path_str);
     };

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -52,7 +52,7 @@ pub fn bits_to_bytes(bits: Vec<bool>) -> Vec<u8> {
 }
 
 pub fn bits_to_usize_truncated(bits: &[bool], max_depth: u32) -> usize {
-  let pow = 1_usize << (max_depth - 1);
+  let pow = 1_usize << (if max_depth > 0 {max_depth - 1} else {max_depth});
   let mut res = 0;
   for (i, bit) in bits.iter().enumerate() {
     if *bit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ pub use types::unsigned32::U32Compressor;
 pub use types::unsigned32::U32Decompressor;
 pub use types::unsigned64::U64Compressor;
 pub use types::unsigned64::U64Decompressor;
+pub use types::boolean8::B8Compressor;
+pub use types::boolean8::B8Decompressor;
 
 pub use constants::MAX_ENTRIES;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ pub use types::unsigned32::U32Compressor;
 pub use types::unsigned32::U32Decompressor;
 pub use types::unsigned64::U64Compressor;
 pub use types::unsigned64::U64Decompressor;
-pub use types::boolean8::B8Compressor;
-pub use types::boolean8::B8Decompressor;
+pub use types::boolean::BoolCompressor;
+pub use types::boolean::BoolDecompressor;
 
 pub use constants::MAX_ENTRIES;
 

--- a/src/types/boolean.rs
+++ b/src/types/boolean.rs
@@ -18,7 +18,7 @@ impl NumberLike for bool {
 pub struct BoolDataType {}
 
 impl DataType<bool> for BoolDataType {
-  const HEADER_BYTE: u8 = 7;
+  const HEADER_BYTE: u8 = 4;
   const BIT_SIZE: usize = 8;
 
   fn offset_diff(upper: bool, lower: bool) -> u64 {
@@ -30,11 +30,11 @@ impl DataType<bool> for BoolDataType {
   }
 
   fn bytes_from(value: bool) -> Vec<u8> {
-    vec![value as u8]
+    (value as u8).to_be_bytes().to_vec()
   }
 
   fn from_bytes(bytes: Vec<u8>) -> bool {
-    bytes[0] != 0
+    u8::from_be_bytes(bytes.try_into().unwrap()) != 0
   }
 }
 

--- a/src/types/boolean.rs
+++ b/src/types/boolean.rs
@@ -15,10 +15,10 @@ impl NumberLike for bool {
   }
 }
 
-pub struct B8DataType {}
+pub struct BoolDataType {}
 
-impl DataType<bool> for B8DataType {
-  const HEADER_BYTE: u8 = 4;
+impl DataType<bool> for BoolDataType {
+  const HEADER_BYTE: u8 = 7;
   const BIT_SIZE: usize = 8;
 
   fn offset_diff(upper: bool, lower: bool) -> u64 {
@@ -30,13 +30,13 @@ impl DataType<bool> for B8DataType {
   }
 
   fn bytes_from(value: bool) -> Vec<u8> {
-    (value as u8).to_be_bytes().to_vec()
+    vec![value as u8]
   }
 
   fn from_bytes(bytes: Vec<u8>) -> bool {
-    u8::from_be_bytes(bytes.try_into().unwrap()) != 0
+    bytes[0] != 0
   }
 }
 
-pub type B8Compressor = Compressor<u8, B8DataType>;
-pub type B8Decompressor = Decompressor<u8, B8DataType>;
+pub type BoolCompressor = Compressor<u8, BoolDataType>;
+pub type BoolDecompressor = Decompressor<u8, BoolDataType>;

--- a/src/types/boolean8.rs
+++ b/src/types/boolean8.rs
@@ -1,0 +1,42 @@
+use std::cmp::Ordering;
+use std::convert::TryInto;
+
+use crate::compressor::Compressor;
+use crate::decompressor::Decompressor;
+use crate::types::{DataType, NumberLike};
+
+impl NumberLike for bool {
+  fn num_eq(&self, other: &Self) -> bool {    
+    self.eq(other)
+  }
+
+  fn num_cmp(&self, other: &Self) -> Ordering {
+    self.cmp(other)
+  }
+}
+
+pub struct B8DataType {}
+
+impl DataType<bool> for B8DataType {
+  const HEADER_BYTE: u8 = 4;
+  const BIT_SIZE: usize = 8;
+
+  fn offset_diff(upper: bool, lower: bool) -> u64 {
+    (upper as u64) - (lower as u64)
+  }
+
+  fn add_offset(lower: bool, off: u64) -> bool {
+    (lower as u64 + off) != 0
+  }
+
+  fn bytes_from(value: bool) -> Vec<u8> {
+    (value as u8).to_be_bytes().to_vec()
+  }
+
+  fn from_bytes(bytes: Vec<u8>) -> bool {
+    u8::from_be_bytes(bytes.try_into().unwrap()) != 0
+  }
+}
+
+pub type B8Compressor = Compressor<u8, B8DataType>;
+pub type B8Decompressor = Decompressor<u8, B8DataType>;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -8,6 +8,7 @@ pub mod signed32;
 pub mod signed64;
 pub mod unsigned32;
 pub mod unsigned64;
+pub mod boolean8;
 
 pub trait NumberLike: Copy + Display + Debug + Default {
   fn num_eq(&self, other: &Self) -> bool;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -8,7 +8,7 @@ pub mod signed32;
 pub mod signed64;
 pub mod unsigned32;
 pub mod unsigned64;
-pub mod boolean8;
+pub mod boolean;
 
 pub trait NumberLike: Copy + Display + Debug + Default {
   fn num_eq(&self, other: &Self) -> bool;


### PR DESCRIPTION
Support for 8-bit (1 byte) booleans via a new `q_compress::types::boolean8::B8DataType` type

Some references:
- https://users.rust-lang.org/t/solved-what-is-byte-value-for-boolean/47347
- https://doc.rust-lang.org/std/primitive.bool.html