### PR TITLE
Rework BitReader to use byte slices

### DIFF
--- a/examples/fast_seeking.rs
+++ b/examples/fast_seeking.rs
@@ -21,7 +21,8 @@ fn main() {
 
   // now read back only the metadata
   let start_t = Instant::now();
-  let mut reader = BitReader::from(writer.pop());
+  let bytes = writer.pop();
+  let mut reader = BitReader::from(&bytes);
   let decompressor = Decompressor::<f64>::default();
   let flags = decompressor.header(&mut reader).expect("flags");
   let mut metadatas = Vec::new();

--- a/examples/primary.rs
+++ b/examples/primary.rs
@@ -28,7 +28,7 @@ trait DtypeHandler<T: 'static> where T: NumberLike {
       .simple_compress(&nums)
   }
 
-  fn decompress(bytes: Vec<u8>) -> Vec<T> {
+  fn decompress(bytes: &[u8]) -> Vec<T> {
     Decompressor::<T>::default()
       .simple_decompress(bytes)
       .expect("could not decompress")
@@ -59,7 +59,7 @@ trait DtypeHandler<T: 'static> where T: NumberLike {
 
     // decompress
     let decompress_start = Instant::now();
-    let rec_nums = Self::decompress(compressed);
+    let rec_nums = Self::decompress(&compressed);
     println!("DECOMPRESSED IN {:?}", Instant::now() - decompress_start);
 
     // make sure everything came back correct

--- a/src/decompressor.rs
+++ b/src/decompressor.rs
@@ -258,7 +258,7 @@ impl<T> Debug for ChunkDecompressor<T> where T: NumberLike {
 /// use q_compress::{BitReader, Decompressor};
 ///
 /// let my_bytes = vec![113, 99, 111, 33, 3, 0, 46]; // the simplest possible .qco file; empty
-/// let mut reader = BitReader::from(my_bytes);
+/// let mut reader = BitReader::from(&my_bytes);
 /// let decompressor = Decompressor::<i32>::default();
 ///
 /// let flags = decompressor.header(&mut reader).expect("header failure");
@@ -418,7 +418,7 @@ impl<T> Decompressor<T> where T: NumberLike {
   pub fn simple_decompress(&self, bytes: Vec<u8>) -> QCompressResult<Vec<T>> {
     // cloning/extending by a single chunk's numbers can slow down by 2%
     // so we just take ownership of the first chunk's numbers instead
-    let mut reader = BitReader::from(bytes);
+    let mut reader = BitReader::from(&bytes);
     let mut res: Option<Vec<T>> = None;
     let flags = self.header(&mut reader)?;
     while let Some(chunk) = self.chunk(&mut reader, &flags)? {
@@ -483,7 +483,7 @@ mod tests {
 
     for bad_metadata in vec![metadata_missing_prefix, metadata_duplicating_prefix] {
       let result = decompressor.chunk_body(
-        &mut BitReader::from(bytes.clone()),
+        &mut BitReader::from(&bytes),
         &flags,
         &bad_metadata,
       );

--- a/src/decompressor.rs
+++ b/src/decompressor.rs
@@ -251,7 +251,7 @@ impl<T> Debug for ChunkDecompressor<T> where T: NumberLike {
 ///
 /// let my_bytes = vec![113, 99, 111, 33, 3, 0, 46]; // the simplest possible .qco file; empty
 /// let decompressor = Decompressor::<i32>::default();
-/// let nums = decompressor.simple_decompress(my_bytes).expect("decompression"); // returns Vec<i32>
+/// let nums = decompressor.simple_decompress(&my_bytes).expect("decompression"); // returns Vec<i32>
 /// ```
 /// You can also get full control over the decompression process:
 /// ```
@@ -415,10 +415,10 @@ impl<T> Decompressor<T> where T: NumberLike {
   /// Takes in compressed bytes and returns a vector of numbers.
   /// Will return an error if there are any compatibility, corruption,
   /// or insufficient data issues.
-  pub fn simple_decompress(&self, bytes: Vec<u8>) -> QCompressResult<Vec<T>> {
+  pub fn simple_decompress(&self, bytes: &[u8]) -> QCompressResult<Vec<T>> {
     // cloning/extending by a single chunk's numbers can slow down by 2%
     // so we just take ownership of the first chunk's numbers instead
-    let mut reader = BitReader::from(&bytes);
+    let mut reader = BitReader::from(bytes);
     let mut res: Option<Vec<T>> = None;
     let flags = self.header(&mut reader)?;
     while let Some(chunk) = self.chunk(&mut reader, &flags)? {

--- a/src/tests/backward_compatibility.rs
+++ b/src/tests/backward_compatibility.rs
@@ -14,7 +14,7 @@ fn assert_compatible<T: NumberLike>(
 
   let compressed = fs::read(format!("assets/{}.qco", filename)).expect("read qco");
   let decompressor = Decompressor::<T>::default();
-  let decompressed = decompressor.simple_decompress(compressed).expect("decompress");
+  let decompressed = decompressor.simple_decompress(&compressed).expect("decompress");
 
   assert_eq!(decompressed, expected)
 }

--- a/src/tests/recovery.rs
+++ b/src/tests/recovery.rs
@@ -110,7 +110,7 @@ fn test_multi_chunk() {
   let bytes = writer.pop();
 
   let decompressor = Decompressor::<i64>::default();
-  let res = decompressor.simple_decompress(bytes).unwrap();
+  let res = decompressor.simple_decompress(&bytes).unwrap();
   assert_eq!(
     res,
     vec![1, 2, 3, 11, 12, 13],
@@ -124,7 +124,7 @@ fn assert_recovers<T: NumberLike>(nums: Vec<T>, compression_level: usize) {
     );
     let compressed = compressor.simple_compress(&nums);
     let decompressor = Decompressor::<T>::default();
-    let decompressed = decompressor.simple_decompress(compressed)
+    let decompressed = decompressor.simple_decompress(&compressed)
       .expect("decompression error");
     // We can't do assert_eq on the whole vector because even bitwise identical
     // floats sometimes aren't equal by ==.

--- a/src/tests/stability.rs
+++ b/src/tests/stability.rs
@@ -13,7 +13,7 @@ fn assert_panic_safe<T: NumberLike>(nums: Vec<T>) -> ChunkMetadata<T> {
 
   let decompressor = Decompressor::<T>::default();
   for i in 0..compressed.len() - 1 {
-    match decompressor.simple_decompress((&compressed[0..i]).to_vec()) {
+    match decompressor.simple_decompress(&compressed[0..i]) {
       Err(e) if matches!(e.kind, ErrorKind::InsufficientData) => (), // good
       Ok(_) => panic!("expected decompressor to notice insufficient data (got Ok)"),
       Err(e) => panic!("expected decompressor to notice insufficient data (got {})", e),


### PR DESCRIPTION
Currently BitReader requires callers to give ownership of the data. Since it
actually never needs to have ownership, rework this so that BitReader instead
stores a reference to a byte slice. This allows callers not having to do unnecessary
copies of the raw data.

Note that this changes the public API (I haven't updated the changelog accordingly).