### PR TITLE
Decompression performance boost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "q_compress"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "rand",
  "zstd",

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -18,7 +18,7 @@ For the `i64` heavy-tail integers, a lomax distribution with alpha parameter 0.5
 
 `i64` and `f64` are each 8 bytes, so for the more interesting distributions
 (e.g. heavy-tail integers and standard normal),
-this is a decompression speed of 200-300MB/s.
+this is a decompression speed of 250-350MB/s.
 
 For reference, on the same hardware and heavy-tail integers dataset, ZStandard
 `0.10.0+zstd.1.5.2` gets:

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -10,11 +10,11 @@ For the `i64` heavy-tail integers, a lomax distribution with alpha parameter 0.5
 
 | dataset | compression speed / (million/s) | decompression speed / (million/s) | compression ratio |
 --- | --- | --- | ---
-| `i64` constant | 41 | 430 | 216,000 |
-| `i64` sparse | 46 | 220 | 597 |
-| `i64` uniform (incompressible) | 12 | 47 | 1.00 |
-| `i64` heavy-tail integers | 13 | 34 | 4.50 |
-| `f64` standard normal | 10 | 26 | 1.15 |
+| `i64` constant | 41 | 390 | 216,000 |
+| `i64` sparse | 46 | 340 | 597 |
+| `i64` uniform (incompressible) | 12 | 52 | 1.00 |
+| `i64` heavy-tail integers | 13 | 43 | 4.50 |
+| `f64` standard normal | 10 | 33 | 1.15 |
 
 `i64` and `f64` are each 8 bytes, so for the more interesting distributions
 (e.g. heavy-tail integers and standard normal),

--- a/q_compress/Cargo.toml
+++ b/q_compress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "q_compress"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 
 authors = ["mwlon <m.w.loncaric@gmail.com>"]

--- a/q_compress/changelog.md
+++ b/q_compress/changelog.md
@@ -1,5 +1,11 @@
 # `q_compress` Changelog
 
+## 0.9.0 (not yet released)
+
+* Improved decompression speed (20-25% in interesting cases, up to 50% in
+sparse case).
+* `BitReader` API changes: no more lifetime parameter and now 
+
 ## 0.8.0
 
 * Improved compression speed in most cases (up to 40%).

--- a/q_compress/changelog.md
+++ b/q_compress/changelog.md
@@ -6,7 +6,8 @@
 sparse case).
 * `BitReader` changes: now reads from `&[usize]` instead of `&[u8]`,
 necessitating a new wrapper type `BitWords` containing both a `Vec<usize>` and
-information about the total number of bits.
+information about the total number of bits. `.read_aligned_bytes()` now returns
+a `Vec<u8>` instead of a slice.
 * `UnsignedLike` changes: no longer requires `From<u8>`, now requires
 `from_word(word: usize) -> Self` instead.
 

--- a/q_compress/changelog.md
+++ b/q_compress/changelog.md
@@ -4,7 +4,11 @@
 
 * Improved decompression speed (20-25% in interesting cases, up to 50% in
 sparse case).
-* `BitReader` API changes: no more lifetime parameter and now 
+* `BitReader` changes: now reads from `&[usize]` instead of `&[u8]`,
+necessitating a new wrapper type `BitWords` containing both a `Vec<usize>` and
+information about the total number of bits.
+* `UnsignedLike` changes: no longer requires `From<u8>`, now requires
+`from_word(word: usize) -> Self` instead.
 
 ## 0.8.0
 

--- a/q_compress/examples/fast_seeking.rs
+++ b/q_compress/examples/fast_seeking.rs
@@ -1,4 +1,4 @@
-use q_compress::{BitWriter, BitReader, Compressor, Decompressor};
+use q_compress::{BitWriter, BitReader, Compressor, Decompressor, BitWords};
 use rand::Rng;
 use std::time::Instant;
 
@@ -21,7 +21,8 @@ fn main() {
 
   // now read back only the metadata
   let bytes = writer.bytes();
-  let mut reader = BitReader::from(&bytes);
+  let words = BitWords::from(&bytes);
+  let mut reader = BitReader::from(&words);
   let start_t = Instant::now();
   let decompressor = Decompressor::<f64>::default();
   let flags = decompressor.header(&mut reader).expect("flags");

--- a/q_compress/src/bit_reader.rs
+++ b/q_compress/src/bit_reader.rs
@@ -6,14 +6,14 @@ use crate::constants::{BITS_TO_ENCODE_N_ENTRIES, BYTES_PER_WORD, WORD_SIZE};
 use crate::data_types::UnsignedLike;
 use crate::errors::{QCompressError, QCompressResult};
 
-/// `BitReader` wraps compressed data during decompression, enabling a
-/// decompressor to read bit-level information and maintain its position in the
-/// data.
+/// Wrapper around compressed data, enabling a
+/// [`Decompressor`][crate::Decompressor] to read
+/// bit-level information and maintain its position in the data.
 ///
 /// It does this with a slice of `usize`s representing the data and
 /// maintaining
 /// * an index into the slice and
-/// * a bit index from 0 to `usize::BITS` within that `usize`.
+/// * a bit index from 0 to `usize::BITS` within the current `usize`.
 ///
 /// The reader is consider is considered "aligned" if the current bit index
 /// is byte-aligned; e.g. `bit_idx % 8 == 0`.

--- a/q_compress/src/bit_reader.rs
+++ b/q_compress/src/bit_reader.rs
@@ -64,7 +64,7 @@ impl<'a> BitReader<'a> {
 
   /// Returns the number of bytes in the reader.
   pub fn byte_size(&self) -> usize {
-    self.total_bits / 8
+    bits::ceil_div(self.total_bits, 8)
   }
 
   fn refresh_if_needed(&mut self) {

--- a/q_compress/src/bit_words.rs
+++ b/q_compress/src/bit_words.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use crate::constants::{BYTES_PER_WORD, WORD_SIZE};
 
 /// A wrapper around a Vec<usize> with a specific number of bits.
-/// 
+///
 /// This is used during decompression because doing bit-level operations on a
 /// `Vec<usize>` is faster than on a `Vec<u8>`; `usize` represents the
 /// true word size of the processor.

--- a/q_compress/src/bit_words.rs
+++ b/q_compress/src/bit_words.rs
@@ -2,7 +2,7 @@ use crate::bits;
 use std::convert::TryInto;
 use crate::constants::{BYTES_PER_WORD, WORD_SIZE};
 
-/// A wrapper around a Vec<usize> with a specific number of bits.
+/// Wrapper around a `Vec<usize>` with a specific number of bits.
 ///
 /// This is used during decompression because doing bit-level operations on a
 /// `Vec<usize>` is faster than on a `Vec<u8>`; `usize` represents the

--- a/q_compress/src/bit_words.rs
+++ b/q_compress/src/bit_words.rs
@@ -1,0 +1,40 @@
+use crate::bits;
+use std::convert::TryInto;
+use crate::constants::{BYTES_PER_WORD, WORD_SIZE};
+
+/// A wrapper around a Vec<usize> with a specific number of bits.
+/// 
+/// This is used during decompression because doing bit-level operations on a
+/// `Vec<usize>` is faster than on a `Vec<u8>`; `usize` represents the
+/// true word size of the processor.
+#[derive(Clone)]
+pub struct BitWords {
+  pub words: Vec<usize>,
+  pub total_bits: usize,
+}
+
+impl<B: AsRef<[u8]>> From<B> for BitWords {
+  fn from(bytes_wrapper: B) -> Self {
+    let bytes = bytes_wrapper.as_ref();
+    let total_bits = 8 * bytes.len();
+    let n_words = bits::ceil_div(total_bits, WORD_SIZE);
+    let mut words = Vec::with_capacity(n_words);
+    words.extend(
+      bytes
+        .chunks_exact(BYTES_PER_WORD)
+        .map(|word_bytes| usize::from_be_bytes(word_bytes.try_into().unwrap()))
+    );
+    if words.len() < n_words {
+      let mut last_bytes = bytes[words.len() * BYTES_PER_WORD..].to_vec();
+      while last_bytes.len() < BYTES_PER_WORD {
+        last_bytes.push(0);
+      }
+      words.push(usize::from_be_bytes(last_bytes.try_into().unwrap()));
+    }
+
+    BitWords {
+      words,
+      total_bits,
+    }
+  }
+}

--- a/q_compress/src/bit_writer.rs
+++ b/q_compress/src/bit_writer.rs
@@ -7,11 +7,11 @@ use crate::constants::{BITS_TO_ENCODE_N_ENTRIES, BYTES_PER_WORD, MAX_ENTRIES, WO
 /// `BitWriter` builds a `Vec<usize>`, enabling a compressor to write bit-level
 /// information and ultimately output a `Vec<u8>`.
 ///
-/// It does this by maintaining a bit index from 0-usize::BITS within its most
-/// recent byte.
+/// It does this by maintaining a bit index from 0 to `usize::BITS` within its
+/// most recent `usize`.
 ///
-/// The reader is consider is considered "aligned" if the current bit index
-/// is 0 or usize::BITS (i.e. at the start or end of the current byte).
+/// The writer is consider is considered "aligned" if the current bit index
+/// is byte-aligned; e.g. `bit_idx % 8 == 0`.
 #[derive(Clone)]
 pub struct BitWriter {
   words: Vec<usize>,

--- a/q_compress/src/bit_writer.rs
+++ b/q_compress/src/bit_writer.rs
@@ -1,3 +1,5 @@
+use crate::bits;
+use crate::bits::BASE_BIT_MASK;
 use crate::errors::{QCompressError, QCompressResult};
 use crate::data_types::UnsignedLike;
 use crate::constants::{BITS_TO_ENCODE_N_ENTRIES, BYTES_PER_WORD, MAX_ENTRIES, WORD_SIZE};
@@ -75,7 +77,7 @@ impl BitWriter {
     self.refresh_if_needed();
 
     if b {
-      *self.last_mut() |= 1_usize << (WORD_SIZE - 1 - self.j);
+      *self.last_mut() |= BASE_BIT_MASK >> self.j;
     }
 
     self.j += 1;
@@ -143,7 +145,7 @@ impl BitWriter {
   }
 
   pub(crate) fn finish_byte(&mut self) {
-    self.j = ((self.j + 7) / 8) * 8;
+    self.j = bits::ceil_div(self.j, 8) * 8;
   }
 
   pub(crate) fn overwrite_usize(&mut self, bit_idx: usize, x: usize, n: usize) {
@@ -170,14 +172,8 @@ impl BitWriter {
   /// Returns the bytes produced by the writer.
   pub fn bytes(&self) -> Vec<u8> {
     let byte_size = self.byte_size();
-    // We can't just transmute because many machines are little-endian.
-    let mut res = self.words.iter()
-      .map(|w| w.to_be_bytes())
-      .flatten()
-      .collect::<Vec<_>>();
-    unsafe {
-      res.set_len(byte_size);
-    }
+    let mut res = bits::words_to_bytes(&self.words);
+    res.truncate(byte_size);
     res
   }
 }

--- a/q_compress/src/bit_writer.rs
+++ b/q_compress/src/bit_writer.rs
@@ -4,8 +4,8 @@ use crate::errors::{QCompressError, QCompressResult};
 use crate::data_types::UnsignedLike;
 use crate::constants::{BITS_TO_ENCODE_N_ENTRIES, BYTES_PER_WORD, MAX_ENTRIES, WORD_SIZE};
 
-/// `BitWriter` builds a `Vec<usize>`, enabling a compressor to write bit-level
-/// information and ultimately output a `Vec<u8>`.
+/// Builds compressed data, enabling a [`Compressor`][crate::Compressor] to
+/// write bit-level information and ultimately output a `Vec<u8>`.
 ///
 /// It does this by maintaining a bit index from 0 to `usize::BITS` within its
 /// most recent `usize`.

--- a/q_compress/src/constants.rs
+++ b/q_compress/src/constants.rs
@@ -12,8 +12,10 @@ pub const MAX_JUMPSTART: usize = BITS_TO_ENCODE_N_ENTRIES;
 pub const BITS_TO_ENCODE_JUMPSTART: usize = 5;
 pub const BITS_TO_ENCODE_COMPRESSED_BODY_SIZE: usize = 32;
 
-pub const MAX_PREFIX_TABLE_SIZE_LOG: usize = 4; // tuned to maximize performance on intel i5
-// pub const MAX_PREFIX_TABLE_SIZE: usize = 1_usize << MAX_PREFIX_TABLE_SIZE_LOG;
+// MAX_PREFIX_TABLE_SIZE_LOG is a performance tuning parameter
+// Too high, and we use excessive memory and in some cases hurt performance.
+// Too low, and performance drops.
+pub const MAX_PREFIX_TABLE_SIZE_LOG: usize = 6;
 
 pub const WORD_SIZE: usize = usize::BITS as usize;
 pub const BYTES_PER_WORD: usize = WORD_SIZE / 8;
@@ -48,8 +50,8 @@ mod tests {
   }
 
   #[test]
-  fn test_prefix_table_size_fits_in_byte() {
+  fn test_prefix_table_size_fits_in_word() {
     assert!(MAX_PREFIX_TABLE_SIZE_LOG > 0);
-    assert!(MAX_PREFIX_TABLE_SIZE_LOG <= 8);
+    assert!(MAX_PREFIX_TABLE_SIZE_LOG <= WORD_SIZE);
   }
 }

--- a/q_compress/src/constants.rs
+++ b/q_compress/src/constants.rs
@@ -12,8 +12,8 @@ pub const MAX_JUMPSTART: usize = BITS_TO_ENCODE_N_ENTRIES;
 pub const BITS_TO_ENCODE_JUMPSTART: usize = 5;
 pub const BITS_TO_ENCODE_COMPRESSED_BODY_SIZE: usize = 32;
 
-pub const PREFIX_TABLE_SIZE_LOG: usize = 4; // tuned to maximize performance on intel i5
-pub const PREFIX_TABLE_SIZE: usize = 1_usize << PREFIX_TABLE_SIZE_LOG;
+pub const MAX_PREFIX_TABLE_SIZE_LOG: usize = 4; // tuned to maximize performance on intel i5
+// pub const MAX_PREFIX_TABLE_SIZE: usize = 1_usize << MAX_PREFIX_TABLE_SIZE_LOG;
 
 pub const WORD_SIZE: usize = usize::BITS as usize;
 pub const BYTES_PER_WORD: usize = WORD_SIZE / 8;
@@ -49,7 +49,7 @@ mod tests {
 
   #[test]
   fn test_prefix_table_size_fits_in_byte() {
-    assert!(PREFIX_TABLE_SIZE_LOG > 0);
-    assert!(PREFIX_TABLE_SIZE_LOG <= 8);
+    assert!(MAX_PREFIX_TABLE_SIZE_LOG > 0);
+    assert!(MAX_PREFIX_TABLE_SIZE_LOG <= 8);
   }
 }

--- a/q_compress/src/data_types/mod.rs
+++ b/q_compress/src/data_types/mod.rs
@@ -49,11 +49,14 @@ Shl<usize, Output=Self> + Shr<usize, Output=Self> + Sub<Output=Self> {
   const MAX: Self;
   const BITS: usize;
 
+  /// Converts a `usize` into this type. Panics if the conversion is
+  /// impossible.
   fn from_word(word: usize) -> Self;
 
   fn to_f64(self) -> f64;
 
-  /// Shifts the unsigned integer right and returns its lowest bits as a usize.
+  /// Shifts the unsigned integer right and returns its lowest bits as a
+  /// `usize`.
   /// For example,
   /// ```
   /// use q_compress::data_types::UnsignedLike;
@@ -64,7 +67,8 @@ Shl<usize, Output=Self> + Shr<usize, Output=Self> + Sub<Output=Self> {
   /// Used for some bit arithmetic operations during compression.
   fn rshift_word(self, shift: usize) -> usize;
 
-  /// Shifts the unsigned integer left and returns its lowest bits as a usize.
+  /// Shifts the unsigned integer left and returns its lowest bits as a
+  /// `usize`.
   /// For example,
   /// ```
   /// use q_compress::data_types::UnsignedLike;
@@ -95,7 +99,7 @@ Shl<usize, Output=Self> + Shr<usize, Output=Self> + Sub<Output=Self> {
 pub trait NumberLike: Copy + Debug + Display + Default + PartialEq + 'static {
   /// A number from 0-255 that corresponds to the number's data type.
   ///
-  /// Each `NumberLike` implementation should have a different `HeaderByte`.
+  /// Each `NumberLike` implementation should have a different `HEADER_BYTE`.
   /// This byte gets written into the file's header during compression, and
   /// if the wrong header byte shows up during decompression, the decompressor
   /// will return an error.

--- a/q_compress/src/data_types/mod.rs
+++ b/q_compress/src/data_types/mod.rs
@@ -42,12 +42,14 @@ pub trait SignedLike {
 /// Under the hood, when numbers are encoded or decoded, they go through their
 /// corresponding `UnsignedLike` representation.
 pub trait UnsignedLike: Add<Output=Self> + BitAnd<Output=Self> + BitOrAssign +
-Copy + Debug + Display + From<u8> + Ord + PartialOrd +
+Copy + Debug + Display + Ord + PartialOrd +
 Shl<usize, Output=Self> + Shr<usize, Output=Self> + Sub<Output=Self> {
   const ZERO: Self;
   const ONE: Self;
   const MAX: Self;
   const BITS: usize;
+
+  fn from_word(word: usize) -> Self;
 
   fn to_f64(self) -> f64;
 

--- a/q_compress/src/data_types/unsigneds.rs
+++ b/q_compress/src/data_types/unsigneds.rs
@@ -11,6 +11,10 @@ macro_rules! impl_unsigned {
       const MAX: Self = Self::MAX;
       const BITS: usize = Self::BITS as usize;
 
+      fn from_word(word: usize) -> Self {
+        word as Self
+      }
+
       fn to_f64(self) -> f64 {
         self as f64
       }

--- a/q_compress/src/decompressor.rs
+++ b/q_compress/src/decompressor.rs
@@ -70,8 +70,8 @@ fn max_bits_read<T: NumberLike>(p: &Prefix<T>) -> usize {
   } else {
     k_info.k + 1
   };
-  let overshoot_prefix_bits = ((prefix_bits + PREFIX_TABLE_SIZE_LOG - 1)
-    / PREFIX_TABLE_SIZE_LOG) * PREFIX_TABLE_SIZE_LOG;
+  let overshoot_prefix_bits = ((prefix_bits + MAX_PREFIX_TABLE_SIZE_LOG - 1)
+    / MAX_PREFIX_TABLE_SIZE_LOG) * MAX_PREFIX_TABLE_SIZE_LOG;
 
   max(
     prefix_bits + max_jumpstart_bits + max_reps * max_bits_per_offset,

--- a/q_compress/src/decompressor.rs
+++ b/q_compress/src/decompressor.rs
@@ -70,13 +70,8 @@ fn max_bits_read<T: NumberLike>(p: &Prefix<T>) -> usize {
   } else {
     k_info.k + 1
   };
-  let overshoot_prefix_bits = ((prefix_bits + MAX_PREFIX_TABLE_SIZE_LOG - 1)
-    / MAX_PREFIX_TABLE_SIZE_LOG) * MAX_PREFIX_TABLE_SIZE_LOG;
 
-  max(
-    prefix_bits + max_jumpstart_bits + max_reps * max_bits_per_offset,
-    overshoot_prefix_bits,
-  )
+  prefix_bits + max_jumpstart_bits + max_reps * max_bits_per_offset
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -270,7 +265,7 @@ impl<T> NumDecompressor<T> where T: NumberLike {
       let mut temp = Vec::with_capacity(1);
       self.unchecked_decompress_num_block(reader, &mut temp, 1);
       let constant_num = temp[0];
-      for _ in 0..batch_size {
+      while res.len() < batch_size {
         res.push(constant_num);
       }
     } else {

--- a/q_compress/src/delta_encoding.rs
+++ b/q_compress/src/delta_encoding.rs
@@ -49,9 +49,7 @@ fn first_order_deltas_in_place<T: NumberLike<Signed=T> + SignedLike>(nums: &mut 
   for i in 0..nums.len() - 1 {
     nums[i] = nums[i + 1].wrapping_sub(nums[i]);
   }
-  unsafe {
-    nums.set_len(nums.len() - 1);
-  }
+  nums.truncate(nums.len() - 1);
 }
 
 // only valid for order >= 1

--- a/q_compress/src/errors.rs
+++ b/q_compress/src/errors.rs
@@ -45,6 +45,21 @@ impl QCompressError {
   pub(crate) fn insufficient_data<S: AsRef<str>>(message: S) -> Self {
     Self::new(ErrorKind::InsufficientData, message)
   }
+  
+  pub(crate) fn insufficient_data_recipe(
+    name: &str,
+    bits_to_read: usize,
+    bit_idx: usize,
+    total_bits: usize,
+  ) -> Self {
+    Self::insufficient_data(format!(
+        "{}: cannot read {} bits at bit idx {} out of {}",
+        name,
+        bits_to_read,
+        bit_idx,
+        total_bits,
+    ))
+  }
 
   pub(crate) fn invalid_argument<S: AsRef<str>>(message: S) -> Self {
     Self::new(ErrorKind::InvalidArgument, message)

--- a/q_compress/src/lib.rs
+++ b/q_compress/src/lib.rs
@@ -4,6 +4,7 @@
 #[doc = include_str!("../README.md")]
 
 pub use bit_reader::BitReader;
+pub use bit_words::BitWords;
 pub use bit_writer::BitWriter;
 pub use chunk_metadata::{ChunkMetadata, DecompressedChunk, PrefixMetadata};
 pub use compressor::{Compressor, CompressorConfig};
@@ -15,6 +16,7 @@ pub mod data_types;
 pub mod errors;
 
 mod bit_reader;
+mod bit_words;
 mod bit_writer;
 mod bits;
 mod chunk_metadata;

--- a/q_compress/src/prefix.rs
+++ b/q_compress/src/prefix.rs
@@ -173,6 +173,7 @@ pub struct PrefixDecompressionInfo<Diff> where Diff: UnsignedLike {
   pub k: usize,
   pub depth: usize,
   pub run_len_jumpstart: Option<usize>,
+  pub most_significant: Diff,
 }
 
 impl<Diff: UnsignedLike> Default for PrefixDecompressionInfo<Diff> {
@@ -183,6 +184,7 @@ impl<Diff: UnsignedLike> Default for PrefixDecompressionInfo<Diff> {
       k: Diff::BITS,
       depth: 0,
       run_len_jumpstart: None,
+      most_significant: Diff::ZERO,
     }
   }
 }
@@ -192,12 +194,18 @@ impl<T> From<&Prefix<T>> for PrefixDecompressionInfo<T::Unsigned> where T: Numbe
     let lower_unsigned = p.lower.to_unsigned();
     let upper_unsigned = p.upper.to_unsigned();
     let KInfo { k, only_k_bits_lower: _, only_k_bits_upper: _ } = p.k_info();
+    let most_significant = if k == T::PHYSICAL_BITS {
+      T::Unsigned::ZERO
+    } else {
+      T::Unsigned::ONE << k
+    };
     PrefixDecompressionInfo {
       lower_unsigned,
       range: upper_unsigned - lower_unsigned,
       k,
       run_len_jumpstart: p.run_len_jumpstart,
       depth: p.code.len(),
+      most_significant,
     }
   }
 }

--- a/q_compress/src/tests/low_level.rs
+++ b/q_compress/src/tests/low_level.rs
@@ -1,4 +1,5 @@
 use crate::{BitReader, BitWriter, Compressor, CompressorConfig, Decompressor};
+use crate::bit_words::BitWords;
 use crate::data_types::NumberLike;
 
 #[test]
@@ -40,7 +41,8 @@ fn assert_lowest_level_behavior<T: NumberLike>(numss: Vec<Vec<T>>) {
     compressor.footer(&mut writer).unwrap();
 
     let bytes = writer.bytes();
-    let mut reader = BitReader::from(&bytes);
+    let words = BitWords::from(&bytes);
+    let mut reader = BitReader::from(&words);
 
     let decompressor = Decompressor::<T>::default();
     let flags = decompressor.header(&mut reader).unwrap();

--- a/q_compress/src/tests/stability.rs
+++ b/q_compress/src/tests/stability.rs
@@ -71,7 +71,7 @@ fn test_insufficient_data_long_offsets() {
   let n = 1000;
   let mut nums = Vec::new();
   for i in 0..n {
-    nums.push(0 + (u64::MAX / n) * i);
+    nums.push((u64::MAX / n) * i);
   }
 
 

--- a/q_compress_cli/src/inspect_handler.rs
+++ b/q_compress_cli/src/inspect_handler.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use q_compress::{BitReader, Decompressor, Prefix, PrefixMetadata};
+use q_compress::{BitReader, BitWords, Decompressor, Prefix, PrefixMetadata};
 use q_compress::data_types::NumberLike;
 
 use crate::handlers::HandlerImpl;
@@ -30,7 +30,8 @@ impl<T: NumberLike> InspectHandler for HandlerImpl<T> {
     let decompressor = Decompressor::<T>::default();
     println!("inspecting {:?}", opt.path);
 
-    let mut reader = BitReader::from(bytes);
+    let words = BitWords::from(bytes);
+    let mut reader = BitReader::from(&words);
     let flags = decompressor.header(&mut reader)?;
     println!("=================\n");
     println!("data type: {}", utils::dtype_name::<T>());


### PR DESCRIPTION
* Using BitReader operating on `usize` instead of `u8`
* Allowing variable-sized Huffman decompression tables