### PR TITLE
Small data compression performance

### DIFF
--- a/q_compress/examples/generate_randoms.py
+++ b/q_compress/examples/generate_randoms.py
@@ -154,6 +154,6 @@ int_floats = np.random.randint(0, 2 ** 30, size=n)
 write_f64(int_floats, 'integers')
 
 # decimal floats, a very antagonistic case
-antagonistic_floats = np.random.randint(1000, 10000, size=n) / 100
-write_f64(antagonistic_floats[:short_n], 'antag_short')
-write_f64(antagonistic_floats, 'antag_long')
+decimal_floats = np.random.randint(1000, 10000, size=n) / 100
+write_f64(decimal_floats[:short_n], 'decimal_short')
+write_f64(decimal_floats, 'decimal_long')

--- a/q_compress/examples/generate_randoms.py
+++ b/q_compress/examples/generate_randoms.py
@@ -9,6 +9,7 @@ import os
 
 np.random.seed(0)
 n = 1000000
+short_n = 3000
 
 base_dir = 'q_compress/examples/data'
 
@@ -22,9 +23,9 @@ os.makedirs(f'{base_dir}/binary', exist_ok=True)
 def write_parquet_tables(nums, full_name):
   print(f'writing parquet for {full_name}...')
   table = pa.Table.from_pydict({'nums': nums})
-  pq.write_table(table, f'{base_dir}/parquet/{full_name}.parquet', compression='NONE')
-  pq.write_table(table, f'{base_dir}/snappy_parquet/{full_name}.snappy.parquet', compression='snappy')
-  pq.write_table(table, f'{base_dir}/gzip_parquet/{full_name}.gzip.parquet', compression='gzip', compression_level=9)
+#   pq.write_table(table, f'{base_dir}/parquet/{full_name}.parquet', compression='NONE')
+#   pq.write_table(table, f'{base_dir}/snappy_parquet/{full_name}.snappy.parquet', compression='snappy')
+#   pq.write_table(table, f'{base_dir}/gzip_parquet/{full_name}.gzip.parquet', compression='gzip', compression_level=9)
   pq.write_table(table, f'{base_dir}/zstd_parquet/{full_name}.zstd.parquet', compression='zstd', compression_level=22)
 
 def write_i64(arr, name):
@@ -151,3 +152,8 @@ write_timestamp_micros(milli_micro_timestamps, 'millis')
 # integers compressed as floats
 int_floats = np.random.randint(0, 2 ** 30, size=n)
 write_f64(int_floats, 'integers')
+
+# decimal floats, a very antagonistic case
+antagonistic_floats = np.random.randint(1000, 10000, size=n) / 100
+write_f64(antagonistic_floats[:short_n], 'antag_short')
+write_f64(antagonistic_floats, 'antag_long')

--- a/q_compress/src/bits.rs
+++ b/q_compress/src/bits.rs
@@ -2,6 +2,19 @@ use crate::constants::WORD_SIZE;
 use crate::data_types::UnsignedLike;
 
 pub const BASE_BIT_MASK: usize = 1 << (WORD_SIZE - 1);
+const MAX_K: usize = 129;
+const LOG_POWS: [(f64, f64); MAX_K] = {
+  let mut res = [(0.0, 0.0); MAX_K];
+  let mut k = 0;
+  let exp_bit = 1_u64 << 52;
+  while k < MAX_K {
+    let mem_repr_exp = exp_bit * (k + 1023 + 1) as u64;
+    res[k] = ((k + 2) as f64, unsafe { std::mem::transmute(mem_repr_exp) });
+    k += 1;
+  }
+  res
+};
+
 
 pub fn bit_from_word(word: usize, j: usize) -> bool {
   (word & (BASE_BIT_MASK >> j)) > 0
@@ -75,11 +88,11 @@ pub fn bits_to_string(bits: &[bool]) -> String {
     .join("");
 }
 
+#[inline(always)]
 fn bumpy_log(x: f64) -> f64 {
-  let k = x.log2().floor();
-  let two_to_k = 2.0_f64.powf(k);
-  let overshoot = x - two_to_k;
-  k + 2.0 * overshoot / x
+  let k = x.log2() as usize;
+  let (base, exp) = LOG_POWS[k];
+  base - exp / x
 }
 
 pub fn avg_offset_bits<U: UnsignedLike>(lower: U, upper: U, gcd: U) -> f64 {
@@ -154,5 +167,23 @@ mod tests {
       byte_28_128,
       vec![28, 128]
     );
+  }
+
+  #[test]
+  fn test_log_pows() {
+    assert_eq!(LOG_POWS[0], (2.0, 2.0));
+    assert_eq!(LOG_POWS[1], (3.0, 4.0));
+    assert_eq!(LOG_POWS[2], (4.0, 8.0));
+    assert_eq!(LOG_POWS[70], (72.0, 2.0_f64.powi(71)));
+  }
+
+  #[test]
+  fn test_bumpy_log() {
+    assert_eq!(bumpy_log(1.0), 0.0);
+    assert_eq!(bumpy_log(2.0), 1.0);
+    assert!((bumpy_log(3.0) - 1.667).abs() < 0.001);
+    assert_eq!(bumpy_log(4.0), 2.0);
+    assert!((bumpy_log(5.0) - 2.4).abs() < 0.001);
+    assert_eq!(bumpy_log(2.0_f64.powi(128)), 128.0);
   }
 }

--- a/q_compress/src/bits.rs
+++ b/q_compress/src/bits.rs
@@ -2,12 +2,12 @@ use crate::constants::WORD_SIZE;
 use crate::data_types::UnsignedLike;
 
 pub const BASE_BIT_MASK: usize = 1 << (WORD_SIZE - 1);
-const MAX_K: usize = 129;
-const LOG_POWS: [(f64, f64); MAX_K] = {
-  let mut res = [(0.0, 0.0); MAX_K];
+const BUMPY_MAX_K: usize = 129;
+const BUMPY_LOG_TABLE: [(f64, f64); BUMPY_MAX_K] = {
+  let mut res = [(0.0, 0.0); BUMPY_MAX_K];
   let mut k = 0;
   let exp_bit = 1_u64 << 52;
-  while k < MAX_K {
+  while k < BUMPY_MAX_K {
     let mem_repr_exp = exp_bit * (k + 1023 + 1) as u64;
     res[k] = ((k + 2) as f64, unsafe { std::mem::transmute(mem_repr_exp) });
     k += 1;
@@ -90,7 +90,7 @@ pub fn bits_to_string(bits: &[bool]) -> String {
 #[inline(always)]
 fn bumpy_log(x: f64) -> f64 {
   let k = x.log2() as usize;
-  let (base, exp) = LOG_POWS[k];
+  let (base, exp) = BUMPY_LOG_TABLE[k];
   base - exp / x
 }
 
@@ -175,10 +175,10 @@ mod tests {
 
   #[test]
   fn test_log_pows() {
-    assert_eq!(LOG_POWS[0], (2.0, 2.0));
-    assert_eq!(LOG_POWS[1], (3.0, 4.0));
-    assert_eq!(LOG_POWS[2], (4.0, 8.0));
-    assert_eq!(LOG_POWS[70], (72.0, 2.0_f64.powi(71)));
+    assert_eq!(BUMPY_LOG_TABLE[0], (2.0, 2.0));
+    assert_eq!(BUMPY_LOG_TABLE[1], (3.0, 4.0));
+    assert_eq!(BUMPY_LOG_TABLE[2], (4.0, 8.0));
+    assert_eq!(BUMPY_LOG_TABLE[70], (72.0, 2.0_f64.powi(71)));
   }
 
   #[test]

--- a/q_compress/src/bits.rs
+++ b/q_compress/src/bits.rs
@@ -77,9 +77,9 @@ pub fn bits_to_string(bits: &[bool]) -> String {
 
 fn bumpy_log(x: f64) -> f64 {
   let k = x.log2().floor();
-  let two_to_k = (2.0_f64).powf(k);
+  let two_to_k = 2.0_f64.powf(k);
   let overshoot = x - two_to_k;
-  k + (2.0 * overshoot) / x
+  k + 2.0 * overshoot / x
 }
 
 pub fn avg_offset_bits<U: UnsignedLike>(lower: U, upper: U, gcd: U) -> f64 {

--- a/q_compress/src/bits.rs
+++ b/q_compress/src/bits.rs
@@ -15,7 +15,6 @@ const LOG_POWS: [(f64, f64); MAX_K] = {
   res
 };
 
-
 pub fn bit_from_word(word: usize, j: usize) -> bool {
   (word & (BASE_BIT_MASK >> j)) > 0
 }
@@ -95,12 +94,17 @@ fn bumpy_log(x: f64) -> f64 {
   base - exp / x
 }
 
+// This bumpy log gives a more accurate average number of offset bits used.
 pub fn avg_offset_bits<U: UnsignedLike>(lower: U, upper: U, gcd: U) -> f64 {
   bumpy_log(((upper - lower) / gcd).to_f64() + 1.0)
 }
 
+// The true Huffman cost of course depends on the tree. We can statistically
+// model this cost and get slightly different bumpy log formulas,
+// but I haven't found
+// anything that beats a simple log. Plus it's computationally cheap.
 pub fn avg_depth_bits(weight: usize, total_weight: usize) -> f64 {
-  bumpy_log(total_weight as f64 / weight as f64)
+  (total_weight as f64 / weight as f64).log2()
 }
 
 pub fn ceil_div(x: usize, divisor: usize) -> usize {

--- a/q_compress/src/constants.rs
+++ b/q_compress/src/constants.rs
@@ -7,7 +7,6 @@ pub const BITS_TO_ENCODE_DELTA_ENCODING_ORDER: usize = 3;
 pub const MAX_ENTRIES: usize = (1 << 24) - 1;
 pub const BITS_TO_ENCODE_N_ENTRIES: usize = 24;
 pub const BITS_TO_ENCODE_N_PREFIXES: usize = 15;
-pub const MAX_COMPRESSION_LEVEL: usize = 12;
 pub const MAX_JUMPSTART: usize = BITS_TO_ENCODE_N_ENTRIES;
 pub const BITS_TO_ENCODE_JUMPSTART: usize = 5;
 pub const BITS_TO_ENCODE_COMPRESSED_BODY_SIZE: usize = 32;
@@ -21,6 +20,7 @@ pub const WORD_SIZE: usize = usize::BITS as usize;
 pub const BYTES_PER_WORD: usize = WORD_SIZE / 8;
 
 pub const DEFAULT_COMPRESSION_LEVEL: usize = 8;
+pub const MAX_COMPRESSION_LEVEL: usize = 12;
 
 #[cfg(test)]
 mod tests {

--- a/q_compress/src/prefix_optimization.rs
+++ b/q_compress/src/prefix_optimization.rs
@@ -21,8 +21,8 @@ fn prefix_bit_cost<U: UnsignedLike>(
     0.0
   };
   base_meta_cost +
-    gcd_cost +
-    huffman_cost + // extra meta cost depending on length of huffman code
+    gcd_cost + // extra meta cost of storing GCD
+    huffman_cost + // extra meta cost of storing Huffman code
     (offset_cost + huffman_cost) * weight as f64 // body cost
 }
 
@@ -85,7 +85,7 @@ pub fn optimize_prefixes<T: NumberLike>(
       let lower = lower_unsigneds[j];
       if fold_gcd {
         gcd_utils::fold_prefix_gcds_left(
-          lower_unsigneds[j],
+          lower,
           upper_unsigneds[j],
           gcds[j],
           upper,

--- a/q_compress/src/prefix_optimization.rs
+++ b/q_compress/src/prefix_optimization.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+
 use crate::{Flags, gcd_utils, Prefix};
 use crate::bits::{avg_depth_bits, avg_offset_bits};
 use crate::data_types::{NumberLike, UnsignedLike};
@@ -149,6 +150,7 @@ pub fn optimize_prefixes<T: NumberLike>(
 #[cfg(test)]
 mod tests {
   use std::marker::PhantomData;
+
   use crate::Flags;
   use crate::prefix::WeightedPrefix;
   use crate::prefix_optimization::optimize_prefixes;


### PR DESCRIPTION
* Reduced number of prefixes used for small data. Default compression ratio should balance compression time vs compressed size for all n (defaulting to 256 was especially slow in the 100 < n < 16k range). E.g. in the 2^10 <= n < 2^12 range this uses up to 64 prefixes by default.
* Improved prefix optimization speed by about 30%.
* Added a new dataset of decimal-valued floats