### PR TITLE
Run Length for nontrivial prefixes

### DIFF
--- a/q_compress/src/base_compressor.rs
+++ b/q_compress/src/base_compressor.rs
@@ -183,7 +183,14 @@ impl<'a, T: NumberLike> PrefixBuffer<'a, T> {
       T::Unsigned::ONE
     };
     // code and run_len_jumpstart get filled in later
-    let p = Prefix { count, lower, upper, gcd, code: Vec::new(), run_len_jumpstart: None };
+    let p = Prefix {
+      count,
+      lower,
+      upper,
+      gcd,
+      code: Vec::new(),
+      run_len_jumpstart: None,
+    };
     self.seq.push(p);
     self.prefix_idx = new_prefix_idx;
     self.calc_target_j();
@@ -274,10 +281,10 @@ fn train_prefixes<T: NumberLike>(
   // combine adjacent prefixes when advantageous and fill in run_len_jumpstart
   let mut optimized_prefs = prefix_optimization::optimize_prefixes(unoptimized_prefs, flags, n);
 
+  // fill in Huffman codes for the now optimized prefixes
   huffman_encoding::make_huffman_code(&mut optimized_prefs, n);
 
-  let prefixes = optimized_prefs.into_iter().map(Prefix::from).collect();
-  Ok(prefixes)
+  Ok(optimized_prefs)
 }
 
 fn trained_compress_body<U: UnsignedLike>(

--- a/q_compress/src/base_compressor.rs
+++ b/q_compress/src/base_compressor.rs
@@ -171,7 +171,6 @@ impl<'a, T: NumberLike> PrefixBuffer<'a, T> {
     let n_unsigneds = self.n_unsigneds;
 
     let count = j - i;
-    // let frequency = count as f64 / self.n_unsigneds as f64;
     let new_prefix_idx = max(
       self.prefix_idx + 1,
       (j * self.max_n_pref) / n_unsigneds,
@@ -185,19 +184,6 @@ impl<'a, T: NumberLike> PrefixBuffer<'a, T> {
     };
     // code and run_len_jumpstart get filled in later
     let p = Prefix { count, lower, upper, gcd, code: Vec::new(), run_len_jumpstart: None };
-    // } else {
-    //   // The weird case - a range that represents almost all (but not all) the data.
-    //   // We create extra prefixes that can describe `reps` copies of the range at once.
-    //   let config = choose_run_len_jumpstart(count, n_unsigneds);
-    //   WeightedPrefix::new(
-    //     count,
-    //     config.weight,
-    //     lower,
-    //     upper,
-    //     Some(config.jumpstart),
-    //     gcd,
-    //   )
-    // };
     self.seq.push(p);
     self.prefix_idx = new_prefix_idx;
     self.calc_target_j();

--- a/q_compress/src/huffman_encoding.rs
+++ b/q_compress/src/huffman_encoding.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
 use crate::data_types::NumberLike;
-use crate::{Prefix, run_len_utils};
+use crate::{run_len_utils, Prefix};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct HuffmanItem {
@@ -109,7 +109,7 @@ pub fn make_huffman_code<T: NumberLike>(prefixes: &mut [Prefix<T>], n: usize) {
 #[cfg(test)]
 mod tests {
   use crate::huffman_encoding::make_huffman_code;
-  use crate::prefix::{Prefix};
+  use crate::prefix::Prefix;
 
   fn coded_prefix(weight: usize, code: Vec<bool>) -> Prefix<i32> {
     Prefix {

--- a/q_compress/src/huffman_encoding.rs
+++ b/q_compress/src/huffman_encoding.rs
@@ -86,7 +86,7 @@ pub fn make_huffman_code<T: NumberLike>(prefixes: &mut [Prefix<T>], n: usize) {
   let mut heap = BinaryHeap::with_capacity(n_pref); // for figuring out huffman tree
   let mut items = Vec::with_capacity(n_pref); // for modifying item codes
   for (i, prefix) in prefixes.iter().enumerate() {
-    let weight = run_len_utils::run_len_weight(prefix.count, n);
+    let (weight, _) = run_len_utils::weight_and_jumpstart_cost(prefix.count, n);
     let item = HuffmanItem::new(weight, i);
     heap.push(item.clone());
     items.push(item);

--- a/q_compress/src/num_decompressor.rs
+++ b/q_compress/src/num_decompressor.rs
@@ -1,7 +1,9 @@
 use std::cmp::{max, min};
 
 use crate::bit_reader::BitReader;
-use crate::constants::{BITS_TO_ENCODE_N_ENTRIES, MAX_DELTA_ENCODING_ORDER, MAX_ENTRIES, MAX_PREFIX_TABLE_SIZE_LOG};
+use crate::constants::{
+  BITS_TO_ENCODE_N_ENTRIES, MAX_DELTA_ENCODING_ORDER, MAX_ENTRIES, MAX_PREFIX_TABLE_SIZE_LOG,
+};
 use crate::data_types::{NumberLike, UnsignedLike};
 use crate::errors::{ErrorKind, QCompressError, QCompressResult};
 use crate::gcd_utils::{GcdOperator, GeneralGcdOp, TrivialGcdOp};

--- a/q_compress/src/prefix.rs
+++ b/q_compress/src/prefix.rs
@@ -96,39 +96,6 @@ impl<T: NumberLike> Prefix<T> {
   }
 }
 
-// used during compression to determine Huffman codes
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WeightedPrefix<T: NumberLike> {
-  pub prefix: Prefix<T>,
-  // How to weight this prefix during huffman coding,
-  // in contrast to prefix.count, which is the actual number of training
-  // entries belonging to it.
-  // Usually these are the same, but a prefix with repetitions will have lower
-  // weight than count.
-  pub weight: usize,
-}
-
-impl<T: NumberLike> WeightedPrefix<T> {
-  pub fn new(
-    count: usize,
-    weight: usize,
-    lower: T,
-    upper: T,
-    run_len_jumpstart: Option<usize>,
-    gcd: T::Unsigned,
-  ) -> WeightedPrefix<T> {
-    let prefix = Prefix {
-      count,
-      lower,
-      upper,
-      code: Vec::new(),
-      run_len_jumpstart,
-      gcd,
-    };
-    WeightedPrefix { prefix, weight }
-  }
-}
-
 #[derive(Clone, Copy, Debug)]
 pub struct PrefixCompressionInfo<U: UnsignedLike> {
   pub count: usize,

--- a/q_compress/src/prefix_optimization.rs
+++ b/q_compress/src/prefix_optimization.rs
@@ -23,7 +23,7 @@ fn prefix_bit_cost<U: UnsignedLike>(
   base_meta_cost +
     gcd_cost + // extra meta cost of storing GCD
     huffman_cost + // extra meta cost of storing Huffman code
-    (huffman_cost + jumpstart_cost) * (weight as f64 + 1.0) +
+    (huffman_cost + jumpstart_cost) * (weight as f64) +
     offset_cost * count as f64
 }
 

--- a/q_compress/src/prefix_optimization.rs
+++ b/q_compress/src/prefix_optimization.rs
@@ -12,7 +12,7 @@ fn prefix_bit_cost<U: UnsignedLike>(
   gcd: U,
 ) -> f64 {
   let offset_cost = avg_offset_bits(lower, upper, gcd);
-  let weight = run_len_utils::run_len_weight(count, n);
+  let (weight, jumpstart_cost) = run_len_utils::weight_and_jumpstart_cost(count, n);
   let total_weight = n + weight - count;
   let huffman_cost = avg_depth_bits(weight, total_weight);
   let gcd_cost = if gcd > U::ONE {
@@ -23,7 +23,7 @@ fn prefix_bit_cost<U: UnsignedLike>(
   base_meta_cost +
     gcd_cost + // extra meta cost of storing GCD
     huffman_cost + // extra meta cost of storing Huffman code
-    huffman_cost * (weight as f64 + 1.0) +
+    (huffman_cost + jumpstart_cost) * (weight as f64 + 1.0) +
     offset_cost * count as f64
 }
 

--- a/q_compress/src/prefix_optimization.rs
+++ b/q_compress/src/prefix_optimization.rs
@@ -1,7 +1,7 @@
 use crate::bits::{avg_depth_bits, avg_offset_bits};
 use crate::data_types::{NumberLike, UnsignedLike};
-use crate::{gcd_utils, Flags, Prefix};
 use crate::run_len_utils;
+use crate::{gcd_utils, Flags, Prefix};
 
 fn prefix_bit_cost<U: UnsignedLike>(
   base_meta_cost: f64,
@@ -61,7 +61,7 @@ pub fn optimize_prefixes<T: NumberLike>(
     flags.bits_to_encode_code_len() as f64 +
     if flags.use_gcds { 1.0 } else { 0.0 } + // bit to say whether there is GCD or not
     1.0; // bit to say there is no run len jumpstart
-  // determine whether we can skip GCD folding to improve performance in some cases
+         // determine whether we can skip GCD folding to improve performance in some cases
   let fold_gcd = gcd_utils::use_gcd_prefix_optimize(&prefixes, flags);
 
   for i in 0..prefixes.len() {
@@ -83,12 +83,12 @@ pub fn optimize_prefixes<T: NumberLike>(
       }
       let cost = best_costs[j]
         + prefix_bit_cost::<T::Unsigned>(
-        base_meta_cost,
-        lower,
-        upper,
-        cum_count_i - cum_count[j],
-        n,
-        gcd_acc.unwrap_or(T::Unsigned::ONE),
+          base_meta_cost,
+          lower,
+          upper,
+          cum_count_i - cum_count[j],
+          n,
+          gcd_acc.unwrap_or(T::Unsigned::ONE),
         );
       if cost < best_cost {
         best_cost = cost;
@@ -162,46 +162,46 @@ mod tests {
 
   #[test]
   fn test_optimize_trivial_ranges_gcd() {
-    let wps = vec![
+    let prefs = vec![
       make_prefix(1, 1000, 1000, 1),
       make_prefix(1, 2000, 2000, 1),
       make_prefix(1, 3000, 3000, 1),
       make_prefix(1, 4000, 4000, 1),
     ];
-    let res = optimize_prefixes(wps, &basic_flags(), 4);
+    let res = optimize_prefixes(prefs, &basic_flags(), 4);
     let expected = vec![make_prefix(4, 1000, 4000, 1000)];
     assert_eq!(res, expected);
   }
 
   #[test]
   fn test_optimize_single_nontrivial_range_gcd() {
-    let wps = vec![
+    let prefs = vec![
       make_prefix(100, 1000, 2000, 10),
       make_prefix(1, 2100, 2100, 1),
     ];
-    let res = optimize_prefixes(wps, &basic_flags(), 101);
+    let res = optimize_prefixes(prefs, &basic_flags(), 101);
     let expected = vec![make_prefix(101, 1000, 2100, 10)];
     assert_eq!(res, expected);
   }
 
   #[test]
   fn test_optimize_nontrivial_ranges_gcd() {
-    let wps = vec![
+    let prefs = vec![
       make_prefix(5, 1000, 1100, 10),
       make_prefix(5, 1105, 1135, 15),
     ];
-    let res = optimize_prefixes(wps, &basic_flags(), 10);
+    let res = optimize_prefixes(prefs, &basic_flags(), 10);
     let expected = vec![make_prefix(10, 1000, 1135, 5)];
     assert_eq!(res, expected);
   }
 
   #[test]
   fn test_optimize_nontrivial_misaligned_ranges_gcd() {
-    let wps = vec![
+    let prefs = vec![
       make_prefix(100, 1000, 1100, 10),
       make_prefix(100, 1101, 1201, 10),
     ];
-    let res = optimize_prefixes(wps, &basic_flags(), 200);
+    let res = optimize_prefixes(prefs, &basic_flags(), 200);
     let expected = vec![
       make_prefix(100, 1000, 1100, 10),
       make_prefix(100, 1101, 1201, 10),

--- a/q_compress/src/run_len_utils.rs
+++ b/q_compress/src/run_len_utils.rs
@@ -26,6 +26,7 @@ pub fn run_len_jumpstart(count: usize, n: usize) -> Option<usize> {
   }
 }
 
+#[inline]
 pub fn weight_and_jumpstart_cost(count: usize, n: usize) -> (usize, f64) {
   let freq = (count as f64) / (n as f64);
   if prefix_needs_run_len(count, n, freq) {

--- a/q_compress/src/run_len_utils.rs
+++ b/q_compress/src/run_len_utils.rs
@@ -1,4 +1,3 @@
-use std::cmp::min;
 use crate::bit_reader::BitReader;
 use crate::constants::{MAX_JUMPSTART, MIN_FREQUENCY_TO_USE_RUN_LEN, MIN_N_TO_USE_RUN_LEN};
 use crate::data_types::{NumberLike, UnsignedLike};
@@ -6,11 +5,10 @@ use crate::gcd_utils::GcdOperator;
 use crate::num_decompressor::NumDecompressor;
 use crate::prefix::PrefixDecompressionInfo;
 use crate::Prefix;
+use std::cmp::min;
 
 fn prefix_needs_run_len(count: usize, n: usize, freq: f64) -> bool {
-  n >= MIN_N_TO_USE_RUN_LEN
-    && freq >= MIN_FREQUENCY_TO_USE_RUN_LEN
-    && count < n
+  n >= MIN_N_TO_USE_RUN_LEN && freq >= MIN_FREQUENCY_TO_USE_RUN_LEN && count < n
 }
 
 pub fn run_len_jumpstart(count: usize, n: usize) -> Option<usize> {

--- a/q_compress/src/run_len_utils.rs
+++ b/q_compress/src/run_len_utils.rs
@@ -26,13 +26,15 @@ pub fn run_len_jumpstart(count: usize, n: usize) -> Option<usize> {
   }
 }
 
-pub fn run_len_weight(count: usize, n: usize) -> usize {
+pub fn weight_and_jumpstart_cost(count: usize, n: usize) -> (usize, f64) {
   let freq = (count as f64) / (n as f64);
   if prefix_needs_run_len(count, n, freq) {
     let non_freq = 1.0 - freq;
-    (freq * non_freq * n as f64).ceil() as usize
+    let weight = (freq * non_freq * n as f64).ceil() as usize;
+    let jumpstart_cost = (-non_freq.log2()).ceil() + 1.0;
+    (weight, jumpstart_cost)
   } else {
-    count
+    (count, 0.0)
   }
 }
 

--- a/q_compress/src/tests/recovery.rs
+++ b/q_compress/src/tests/recovery.rs
@@ -1,8 +1,8 @@
 use crate::data_types::{NumberLike, TimestampMicros, TimestampNanos};
 use crate::errors::QCompressResult;
 use crate::{Compressor, CompressorConfig, Decompressor};
-use std::io::Write;
 use rand::Rng;
+use std::io::Write;
 
 #[test]
 fn test_edge_cases() {

--- a/q_compress/src/tests/recovery.rs
+++ b/q_compress/src/tests/recovery.rs
@@ -2,6 +2,7 @@ use crate::data_types::{NumberLike, TimestampMicros, TimestampNanos};
 use crate::errors::QCompressResult;
 use crate::{Compressor, CompressorConfig, Decompressor};
 use std::io::Write;
+use rand::Rng;
 
 #[test]
 fn test_edge_cases() {
@@ -187,6 +188,20 @@ fn test_with_gcds() {
     sparse_with_gcd.push(7);
   }
   assert_recovers(sparse_with_gcd, 4, "sparse with gcd");
+}
+
+#[test]
+fn test_sparse_islands() {
+  let mut rng = rand::thread_rng();
+  let mut nums = Vec::new();
+  // sparse - one common island of [0, 8) and one rare of [1000, 1008)
+  for _ in 0..20 {
+    for _ in 0..99 {
+      nums.push(rng.gen_range(0..8))
+    }
+    nums.push(rng.gen_range(1000..1008))
+  }
+  assert_recovers(nums, 4, "sparse islands");
 }
 
 fn assert_recovers<T: NumberLike>(nums: Vec<T>, compression_level: usize, name: &str) {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
-tab_spaces = 2
+edition = "2018"
 fn_call_width = 45
+tab_spaces = 2


### PR DESCRIPTION
Improved compression in some important cases; some performance loss at very high compression levels.

I am baffled that I was able to do this (something I had initially thought difficult) while decreasing source code size.