### PR TITLE
Float mult fix

### DIFF
--- a/durendal/src/data_types/floats.rs
+++ b/durendal/src/data_types/floats.rs
@@ -28,15 +28,7 @@ macro_rules! impl_float_number {
 
       #[inline]
       fn round(self) -> Self {
-        // Unfortunately rounding alone isn't enough, because numbers can round
-        // to -0, which is different from how they'll come out after conversion
-        // to integers.
-        let maybe_neg_zero = self.round();
-        if maybe_neg_zero == -0.0 {
-          0.0
-        } else {
-          maybe_neg_zero
-        }
+        self.round()
       }
 
       #[inline]

--- a/durendal/src/data_types/unsigneds.rs
+++ b/durendal/src/data_types/unsigneds.rs
@@ -1,5 +1,5 @@
 use crate::constants::Bitlen;
-use crate::data_types::{NumberLike, UnsignedLike};
+use crate::data_types::{FloatLike, NumberLike, UnsignedLike};
 
 macro_rules! impl_unsigned {
   ($t: ty, $float: ty, $signed: ty) => {
@@ -44,12 +44,39 @@ macro_rules! impl_unsigned {
 
       #[inline]
       fn to_int_float(self) -> Self::Float {
-        <$signed>::from_unsigned(self) as Self::Float
+        let (negative, abs_int) = if self >= Self::MID {
+          (false, self - Self::MID)
+        } else {
+          (true, Self::MID - 1 - self)
+        };
+        let gpi = <$float>::GREATEST_PRECISE_INT;
+        let abs_float = if abs_int < gpi as Self {
+          abs_int as $float
+        } else {
+          <$float>::from_bits(gpi.to_bits() + (abs_int - gpi as Self))
+        };
+        if negative {
+          -abs_float
+        } else {
+          abs_float
+        }
       }
 
       #[inline]
       fn from_int_float(float: Self::Float) -> Self {
-        (float as $signed).to_unsigned()
+        let abs = float.abs();
+        let gpi = <$float>::GREATEST_PRECISE_INT;
+        let abs_int = if abs < gpi {
+          abs as Self
+        } else {
+          gpi as Self + (abs.to_bits() - gpi.to_bits())
+        };
+        if float.is_sign_positive() {
+          Self::MID + abs_int
+        } else {
+          // -1 because we need to distinguish -0.0 from +0.0
+          Self::MID - 1 - abs_int
+        }
       }
 
       #[inline]
@@ -101,3 +128,50 @@ macro_rules! impl_unsigned_number {
 
 impl_unsigned_number!(u32, i32, f32, 4);
 impl_unsigned_number!(u64, i64, f64, 2);
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn int_float32_invertibility() {
+    for x in [
+      -f32::NAN, f32::NEG_INFINITY, f32::MIN, -1.0, -0.0, 0.0, 3.0, f32::MAX, f32::INFINITY, f32::NAN,
+    ] {
+      let int = u32::from_int_float(x);
+      let recovered = u32::to_int_float(int);
+      // gotta compare unsigneds because floats don't implement Equal
+      assert_eq!(recovered.to_unsigned(), x.to_unsigned(), "{} != {}", x, recovered);
+    }
+  }
+
+  #[test]
+  fn int_float64_invertibility() {
+    for x in [
+      -f64::NAN, f64::NEG_INFINITY, f64::MIN, -1.0, -0.0, 0.0, 3.0, f64::MAX, f64::INFINITY, f64::NAN,
+    ] {
+      let int = u64::from_int_float(x);
+      let recovered = u64::to_int_float(int);
+      // gotta compare unsigneds because floats don't implement Equal
+      assert_eq!(recovered.to_unsigned(), x.to_unsigned(), "{} != {}", x, recovered);
+    }
+  }
+
+  #[test]
+  fn int_float_ordering() {
+    let values = vec![-f32::NAN, f32::NEG_INFINITY, f32::MIN, -1.0, -0.0, 0.0, 3.0,
+                      f32::GREATEST_PRECISE_INT,
+                      f32::MAX, f32::INFINITY, f32::NAN];
+    let mut last_int = None;
+    for x in values {
+      let int = u32::from_int_float(x);
+      if let Some(last_int) = last_int {
+        assert!(last_int < int, "at {}; int {} vs {}", x, last_int, int);
+      }
+      last_int = Some(int)
+    }
+
+    assert_eq!(u32::from_int_float(f32::GREATEST_PRECISE_INT) - 1, u32::from_int_float(f32::GREATEST_PRECISE_INT - 1.0));
+    assert_eq!(u32::from_int_float(f32::GREATEST_PRECISE_INT) + 1, u32::from_int_float(f32::GREATEST_PRECISE_INT + 2.0));
+  }
+}

--- a/durendal/src/data_types/unsigneds.rs
+++ b/durendal/src/data_types/unsigneds.rs
@@ -136,42 +136,94 @@ mod tests {
   #[test]
   fn int_float32_invertibility() {
     for x in [
-      -f32::NAN, f32::NEG_INFINITY, f32::MIN, -1.0, -0.0, 0.0, 3.0, f32::MAX, f32::INFINITY, f32::NAN,
+      -f32::NAN,
+      f32::NEG_INFINITY,
+      f32::MIN,
+      -1.0,
+      -0.0,
+      0.0,
+      3.0,
+      f32::MAX,
+      f32::INFINITY,
+      f32::NAN,
     ] {
       let int = u32::from_int_float(x);
       let recovered = u32::to_int_float(int);
       // gotta compare unsigneds because floats don't implement Equal
-      assert_eq!(recovered.to_unsigned(), x.to_unsigned(), "{} != {}", x, recovered);
+      assert_eq!(
+        recovered.to_unsigned(),
+        x.to_unsigned(),
+        "{} != {}",
+        x,
+        recovered
+      );
     }
   }
 
   #[test]
   fn int_float64_invertibility() {
     for x in [
-      -f64::NAN, f64::NEG_INFINITY, f64::MIN, -1.0, -0.0, 0.0, 3.0, f64::MAX, f64::INFINITY, f64::NAN,
+      -f64::NAN,
+      f64::NEG_INFINITY,
+      f64::MIN,
+      -1.0,
+      -0.0,
+      0.0,
+      3.0,
+      f64::MAX,
+      f64::INFINITY,
+      f64::NAN,
     ] {
       let int = u64::from_int_float(x);
       let recovered = u64::to_int_float(int);
       // gotta compare unsigneds because floats don't implement Equal
-      assert_eq!(recovered.to_unsigned(), x.to_unsigned(), "{} != {}", x, recovered);
+      assert_eq!(
+        recovered.to_unsigned(),
+        x.to_unsigned(),
+        "{} != {}",
+        x,
+        recovered
+      );
     }
   }
 
   #[test]
   fn int_float_ordering() {
-    let values = vec![-f32::NAN, f32::NEG_INFINITY, f32::MIN, -1.0, -0.0, 0.0, 3.0,
-                      f32::GREATEST_PRECISE_INT,
-                      f32::MAX, f32::INFINITY, f32::NAN];
+    let values = vec![
+      -f32::NAN,
+      f32::NEG_INFINITY,
+      f32::MIN,
+      -1.0,
+      -0.0,
+      0.0,
+      3.0,
+      f32::GREATEST_PRECISE_INT,
+      f32::MAX,
+      f32::INFINITY,
+      f32::NAN,
+    ];
     let mut last_int = None;
     for x in values {
       let int = u32::from_int_float(x);
       if let Some(last_int) = last_int {
-        assert!(last_int < int, "at {}; int {} vs {}", x, last_int, int);
+        assert!(
+          last_int < int,
+          "at {}; int {} vs {}",
+          x,
+          last_int,
+          int
+        );
       }
       last_int = Some(int)
     }
 
-    assert_eq!(u32::from_int_float(f32::GREATEST_PRECISE_INT) - 1, u32::from_int_float(f32::GREATEST_PRECISE_INT - 1.0));
-    assert_eq!(u32::from_int_float(f32::GREATEST_PRECISE_INT) + 1, u32::from_int_float(f32::GREATEST_PRECISE_INT + 2.0));
+    assert_eq!(
+      u32::from_int_float(f32::GREATEST_PRECISE_INT) - 1,
+      u32::from_int_float(f32::GREATEST_PRECISE_INT - 1.0)
+    );
+    assert_eq!(
+      u32::from_int_float(f32::GREATEST_PRECISE_INT) + 1,
+      u32::from_int_float(f32::GREATEST_PRECISE_INT + 2.0)
+    );
   }
 }

--- a/durendal/src/tests/recovery.rs
+++ b/durendal/src/tests/recovery.rs
@@ -175,7 +175,8 @@ fn test_decimals() -> QCompressResult<()> {
     let adj = rng.gen_range(-1..2);
     nums.push(plus_epsilons(unadjusted_num, adj));
   }
-  nums.resize(2 * n, f64::INFINITY); // some big numbers just to test losslessness
+  // add some big numbers just to test losslessness
+  nums.resize(2 * n, f64::INFINITY);
   // Each regular number should take only 7 bits for offset and 2 bits for
   // adjustment, plus some overhead. Each infinity should take 1 bit plus maybe
   // 2 for adjustment.

--- a/durendal/src/tests/recovery.rs
+++ b/durendal/src/tests/recovery.rs
@@ -175,15 +175,17 @@ fn test_decimals() -> QCompressResult<()> {
     let adj = rng.gen_range(-1..2);
     nums.push(plus_epsilons(unadjusted_num, adj));
   }
-  // each number should take only 7 bits for offset and 2 bits for adjustment,
-  // plus some overhead
-  let overhead_bytes = 50;
+  nums.resize(2 * n, f64::INFINITY); // some big numbers just to test losslessness
+  // Each regular number should take only 7 bits for offset and 2 bits for
+  // adjustment, plus some overhead. Each infinity should take 1 bit plus maybe
+  // 2 for adjustment.
+  let overhead_bytes = 100;
   assert_recovers_within_size(
     &nums,
     2,
     "decimals",
     0,
-    (9 * n) / 8 + overhead_bytes,
+    (9 * n + 3 * n) / 8 + overhead_bytes,
   )?;
   assert_recovers(nums, 2, "decimals")
 }


### PR DESCRIPTION
I had a bug when there were also numbers above 2^bits in magnitude. This may also improve compression ratio for floats between 2^mantissa and 2^bits.