### PR TITLE
test for stack size of different structs

### DIFF
--- a/pco/src/latent_batch_dissector.rs
+++ b/pco/src/latent_batch_dissector.rs
@@ -13,6 +13,7 @@ pub struct LatentBatchDissector<'a, L: Latent> {
   encoder: &'a ans::Encoder,
 
   // mutable
+  // TODO: use an arena and heap-allocate these?
   lower_scratch: [L; FULL_BATCH_N],
   symbol_scratch: [Symbol; FULL_BATCH_N],
 }

--- a/pco/src/latent_page_decompressor.rs
+++ b/pco/src/latent_page_decompressor.rs
@@ -28,6 +28,7 @@ impl<L: Latent> BinDecompressionInfo<L> {
 #[derive(Clone, Debug)]
 struct State<L: Latent> {
   // scratch needs no backup
+  // TODO: use an arena and heap-allocate these?
   offset_bits_csum_scratch: [Bitlen; FULL_BATCH_N],
   offset_bits_scratch: [Bitlen; FULL_BATCH_N],
   lowers_scratch: [L; FULL_BATCH_N],

--- a/pco/src/tests/mod.rs
+++ b/pco/src/tests/mod.rs
@@ -2,3 +2,4 @@ mod compatibility;
 mod low_level;
 mod recovery;
 mod stability;
+mod stack_sizes;

--- a/pco/src/tests/stack_sizes.rs
+++ b/pco/src/tests/stack_sizes.rs
@@ -1,0 +1,38 @@
+use crate::latent_batch_dissector::LatentBatchDissector;
+use crate::latent_chunk_compressor::LatentChunkCompressor;
+use crate::latent_page_decompressor::LatentPageDecompressor;
+use crate::metadata::PerLatentVar;
+use crate::wrapped::{ChunkCompressor, ChunkDecompressor, PageDecompressor};
+use std::mem;
+
+#[test]
+fn test_stack_sizes() {
+  // Some of our structs get pretty large on the stack, so it's good to be
+  // aware of that. Hopefully we can minimize this in the future.
+
+  // compression
+  assert_eq!(
+    mem::size_of::<LatentBatchDissector<u64>>(),
+    3088
+  );
+  assert_eq!(
+    mem::size_of::<LatentChunkCompressor<u64>>(),
+    136
+  );
+  assert_eq!(mem::size_of::<ChunkDecompressor<u64>>(), 168);
+  assert_eq!(mem::size_of::<ChunkCompressor>(), 624);
+
+  // decompression
+  assert_eq!(
+    mem::size_of::<LatentPageDecompressor<u64>>(),
+    4248
+  );
+  assert_eq!(
+    mem::size_of::<PerLatentVar<LatentPageDecompressor<u64>>>(),
+    12744
+  );
+  assert_eq!(
+    mem::size_of::<PageDecompressor<u64, &[u8]>>(),
+    12952
+  );
+}


### PR DESCRIPTION
This is mainly to surface and track the information of how damn large some of these are. We could do something better.

@Skielex this may be informative if you're going to look into startup time performance.