### PR TITLE
Incompatible is corruption

### DIFF
--- a/pco/src/errors.rs
+++ b/pco/src/errors.rs
@@ -6,13 +6,11 @@ use std::{fmt, io};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ErrorKind {
-  /// `Compatibility` errors occur during decompression, indicating the library
-  /// version is not up-to-date enough for the provided data.
-  Compatibility,
   /// `Corruption` errors occur during decompression, indicating the
   /// provided data is inconsistent or violates the pco format.
-  /// It also applies to cases where standalone files were read but a wrapped
-  /// format was detected, or vice versa.
+  /// These may arise when the decompressor version is too old.
+  /// They may also apply to cases where standalone files were read using the
+  /// wrapped API, or vice versa.
   Corruption,
   /// `InsufficientData` errors occur during decompression, indicating
   /// the decompressor reached the end of the provided data before finishing.
@@ -38,10 +36,6 @@ impl PcoError {
       kind,
       message: message.as_ref().to_string(),
     }
-  }
-
-  pub(crate) fn compatibility<S: AsRef<str>>(message: S) -> Self {
-    Self::new(ErrorKind::Compatibility, message)
   }
 
   pub(crate) fn corruption<S: AsRef<str>>(message: S) -> Self {

--- a/pco/src/metadata/format_version.rs
+++ b/pco/src/metadata/format_version.rs
@@ -9,7 +9,7 @@ use crate::errors::{PcoError, PcoResult};
 ///
 /// During compression, this gets stored in the file.
 /// Version can affect the encoding of the rest of the file, so older versions
-/// of pco might return compatibility errors when running on data compressed
+/// of pco might return corruption errors when running on data compressed
 /// by newer versions.
 ///
 /// You will not need to manually instantiate this.
@@ -28,7 +28,7 @@ impl FormatVersion {
   pub(crate) fn read_from(reader: &mut BitReader) -> PcoResult<Self> {
     let version = reader.read_aligned_bytes(1)?[0];
     if version > CURRENT_FORMAT_VERSION {
-      return Err(PcoError::compatibility(format!(
+      return Err(PcoError::corruption(format!(
         "file's format version ({}) exceeds max supported ({}); consider upgrading pco",
         version, CURRENT_FORMAT_VERSION,
       )));

--- a/pco/src/metadata/mode.rs
+++ b/pco/src/metadata/mode.rs
@@ -97,8 +97,8 @@ impl Mode {
       0 => Classic,
       1 => {
         if version.used_old_gcds() {
-          return Err(PcoError::compatibility(
-            "unable to decompress data from v0.0.0 of pco with different GCD encoding",
+          return Err(PcoError::corruption(
+            "unable to decompress data from yanked v0.0.0 of pco with different GCD encoding",
           ));
         }
 

--- a/pco/src/standalone/decompressor.rs
+++ b/pco/src/standalone/decompressor.rs
@@ -77,8 +77,7 @@ impl FileDecompressor {
   /// Reads a short header and returns a `FileDecompressor` and the
   /// remaining input.
   ///
-  /// Will return an error if any corruptions, version incompatibilities, or
-  /// insufficient data are found.
+  /// Will return an error if any corruptions or insufficient data are found.
   pub fn new<R: BetterBufRead>(mut src: R) -> PcoResult<(Self, R)> {
     bit_reader::ensure_buf_read_capacity(&mut src, STANDALONE_HEADER_PADDING);
     let mut reader_builder = BitReaderBuilder::new(src, STANDALONE_HEADER_PADDING, 0);
@@ -115,7 +114,7 @@ impl FileDecompressor {
       })?;
 
     if standalone_version > CURRENT_STANDALONE_VERSION {
-      return Err(PcoError::compatibility(format!(
+      return Err(PcoError::corruption(format!(
         "file's standalone version ({}) exceeds max supported ({}); consider upgrading pco",
         standalone_version, CURRENT_STANDALONE_VERSION,
       )));
@@ -225,8 +224,8 @@ impl FileDecompressor {
   /// Takes in compressed bytes (after the header, at the start of the chunks)
   /// and returns a vector of numbers.
   ///
-  /// Will return an error if there are any compatibility, corruption,
-  /// or insufficient data issues.
+  /// Will return an error if there are any corruption or insufficient data
+  /// issues.
   ///
   /// This function exists (in addition to the [standalone
   /// functions][crate::standalone]) because the user may want to peek at the

--- a/pco/src/standalone/simple.rs
+++ b/pco/src/standalone/simple.rs
@@ -88,8 +88,8 @@ pub fn simple_compress<T: Number>(nums: &[T], config: &ChunkConfig) -> PcoResult
 /// Takes in compressed bytes and writes numbers to the destination, returning
 /// progress into the file.
 ///
-/// Will return an error if there are any compatibility, corruption,
-/// or insufficient data issues.
+/// Will return an error if there are any corruption or or insufficient data
+/// issues.
 /// Does not error if dst is too short or too long, but that can be inferred
 /// from `Progress`.
 pub fn simple_decompress_into<T: Number>(src: &[u8], mut dst: &mut [T]) -> PcoResult<Progress> {
@@ -154,8 +154,8 @@ pub fn simpler_compress<T: Number>(nums: &[T], compression_level: usize) -> PcoR
 
 /// Takes in compressed bytes and returns a vector of numbers.
 ///
-/// Will return an error if there are any compatibility, corruption,
-/// or insufficient data issues.
+/// Will return an error if there are any corruption, or insufficient data
+/// issues.
 pub fn simple_decompress<T: Number>(src: &[u8]) -> PcoResult<Vec<T>> {
   let (file_decompressor, src) = FileDecompressor::new(src)?;
   file_decompressor.simple_decompress(src)

--- a/pco/src/wrapped/file_decompressor.rs
+++ b/pco/src/wrapped/file_decompressor.rs
@@ -22,8 +22,7 @@ impl FileDecompressor {
   /// Reads a short header and returns a `FileDecompressor` and the remaining
   /// input.
   ///
-  /// Will return an error if any version incompatibilities or
-  /// insufficient data are found.
+  /// Will return an error if any corruptions or insufficient data are found.
   pub fn new<R: BetterBufRead>(mut src: R) -> PcoResult<(Self, R)> {
     bit_reader::ensure_buf_read_capacity(&mut src, HEADER_PADDING);
     let mut reader_builder = BitReaderBuilder::new(src, HEADER_PADDING, 0);
@@ -41,8 +40,7 @@ impl FileDecompressor {
   /// Reads a chunk's metadata and returns a `ChunkDecompressor` and the
   /// remaining input.
   ///
-  /// Will return an error if version incompatibilities, corruptions, or
-  /// insufficient data are found.
+  /// Will return an error if corruptions or insufficient data are found.
   pub fn chunk_decompressor<T: Number, R: BetterBufRead>(
     &self,
     mut src: R,


### PR DESCRIPTION
The distinction was pretty tenuous before; in theory, compatibility errors should have only been possible when we could be "certain" they were from requiring a library upgrade, but there's really no way to rule out the possibility that it's just a corrupt file.