### PR TITLE
Cli better args for 8 bit configuration

### DIFF
--- a/pco_cli/src/bench/codecs/pco.rs
+++ b/pco_cli/src/bench/codecs/pco.rs
@@ -1,4 +1,4 @@
-use pco::{ChunkConfig, DeltaSpec, ModeSpec};
+use pco::{DeltaSpec, ModeSpec};
 
 use crate::bench::codecs::CodecInternal;
 use crate::chunk_config_opt::ChunkConfigOpt;

--- a/pco_cli/src/bench/codecs/pco.rs
+++ b/pco_cli/src/bench/codecs/pco.rs
@@ -42,7 +42,9 @@ impl CodecInternal for ChunkConfigOpt {
   }
 
   fn compress<T: PcoNumber>(&self, nums: &[T]) -> Vec<u8> {
-    let chunk_config = self.clone().into_chunk_config(true);
+    let chunk_config = self.clone().into_chunk_config(
+      true, // enable 8 bit because we already filtered down to selected dtypes
+    );
     pco::standalone::simple_compress(nums, &chunk_config).expect("invalid config")
   }
 

--- a/pco_cli/src/bench/codecs/pco.rs
+++ b/pco_cli/src/bench/codecs/pco.rs
@@ -38,18 +38,11 @@ impl CodecInternal for ChunkConfigOpt {
       ("delta", unparse_delta_spec(&self.delta)),
       ("mode", unparse_mode_spec(&self.mode)),
       ("chunk-n", self.chunk_n.to_string()),
-      (
-        "enable-8-bit",
-        match self.enable_8_bit() {
-          true => "t".to_string(),
-          false => "f".to_string(),
-        },
-      ),
     ]
   }
 
   fn compress<T: PcoNumber>(&self, nums: &[T]) -> Vec<u8> {
-    let chunk_config = ChunkConfig::from(self.clone());
+    let chunk_config = self.clone().into_chunk_config(true);
     pco::standalone::simple_compress(nums, &chunk_config).expect("invalid config")
   }
 

--- a/pco_cli/src/bench/mod.rs
+++ b/pco_cli/src/bench/mod.rs
@@ -20,6 +20,7 @@ use pco::data_types::NumberType;
 use pco::match_number_enum;
 
 use crate::bench::codecs::CodecConfig;
+use crate::dtypes::ArrowDataTypes;
 use crate::input::{Format, InputColumnOpt, InputFileOpt};
 use crate::{arrow_handlers, dtypes, input, parse, utils};
 
@@ -66,10 +67,12 @@ pub struct BenchOpt {
   /// By default all datasets are run.
   #[arg(long, short, default_values_t = Vec::<String>::new(), value_delimiter = ',')]
   pub datasets: Vec<String>,
-  /// Filter down to datasets or columns matching this Arrow data type,
-  /// e.g. i32 or micros.
-  #[arg(long, default_values_t = Vec::<DataType>::new(), value_parser = parse::arrow_dtype, value_delimiter = ',')]
-  pub dtypes: Vec<DataType>,
+  /// Filter down to datasets or columns matching only these numerical arrow
+  /// data types, e.g. "i32,f32,millis" or "all_including_8_bit".
+  /// By default, all data types except 8-bit types are included, since 8-bit
+  /// types are often not Pco's intended use case.
+  #[arg(long, default_value = "all_except_8_bit", value_parser = parse::arrow_dtypes)]
+  pub dtypes: ArrowDataTypes,
   /// Number of iterations to run each codec x dataset combination for
   /// better estimation of durations.
   /// The median duration is kept.
@@ -127,9 +130,8 @@ pub struct IterOpt {
 
 impl BenchOpt {
   pub fn includes_dataset(&self, dtype: &DataType, name: &str) -> bool {
-    if dtypes::from_arrow(dtype).is_err()
-      || (!self.dtypes.is_empty() && !self.dtypes.contains(dtype))
-    {
+    let dtypes = &self.dtypes.0;
+    if dtypes::from_arrow(dtype).is_err() || (!dtypes.is_empty() && !dtypes.contains(dtype)) {
       return false;
     }
 

--- a/pco_cli/src/chunk_config_opt.rs
+++ b/pco_cli/src/chunk_config_opt.rs
@@ -22,29 +22,15 @@ pub struct ChunkConfigOpt {
   pub mode: ModeSpec,
   #[arg(long, default_value_t = pco::DEFAULT_MAX_PAGE_N)]
   pub chunk_n: usize,
-  // We can't use default value here because clap will force it to be a no-args
-  // flag, and that doesn't work with the k=v args we use in bench
-  /// Can be "t" or "f".
-  ///
-  /// This must be "t" to enable compression of 8-bit data types.
-  #[arg(long, value_parser = parse::boolean)]
-  enable_8_bit: Option<bool>,
 }
 
 impl ChunkConfigOpt {
-  pub fn enable_8_bit(&self) -> bool {
-    self.enable_8_bit.unwrap_or(false)
-  }
-}
-
-impl From<ChunkConfigOpt> for ChunkConfig {
-  fn from(opt: ChunkConfigOpt) -> Self {
-    let enable_8_bit = opt.enable_8_bit();
+  pub fn into_chunk_config(self, enable_8_bit: bool) -> ChunkConfig {
     ChunkConfig::default()
-      .with_compression_level(opt.level)
-      .with_delta_spec(opt.delta)
-      .with_mode_spec(opt.mode)
-      .with_paging_spec(PagingSpec::EqualPagesUpTo(opt.chunk_n))
+      .with_compression_level(self.level)
+      .with_delta_spec(self.delta)
+      .with_mode_spec(self.mode)
+      .with_paging_spec(PagingSpec::EqualPagesUpTo(self.chunk_n))
       .with_enable_8_bit(enable_8_bit)
   }
 }

--- a/pco_cli/src/compress/handler.rs
+++ b/pco_cli/src/compress/handler.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use arrow::datatypes::Schema;
 
 use pco::standalone::FileCompressor;
-use pco::ChunkConfig;
 
 use crate::arrow_handlers::ArrowHandlerImpl;
 use crate::compress::CompressOpt;

--- a/pco_cli/src/compress/handler.rs
+++ b/pco_cli/src/compress/handler.rs
@@ -29,7 +29,7 @@ impl<P: ArrowNumber> CompressHandler for ArrowHandlerImpl<P> {
     let file = open_options.open(&opt.path)?;
 
     let chunk_size = opt.chunk_config.chunk_n;
-    let config = ChunkConfig::from(opt.chunk_config);
+    let config = opt.chunk_config.into_chunk_config(opt.enable_8_bit);
     let fc = FileCompressor::default();
     fc.write_header(&file)?;
 

--- a/pco_cli/src/compress/mod.rs
+++ b/pco_cli/src/compress/mod.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::Parser;
 
 use crate::input::{InputColumnOpt, InputFileOpt};
+use crate::parse;
 use crate::{arrow_handlers, chunk_config_opt, input, utils};
 
 pub mod handler;
@@ -20,6 +21,11 @@ pub struct CompressOpt {
   pub input_column: InputColumnOpt,
   #[command(flatten)]
   pub chunk_config: chunk_config_opt::ChunkConfigOpt,
+  /// Enables compression of 8-bit integer types.
+  /// By default, such types are ignored because they are often not Pco's
+  /// intended use case.
+  #[arg(long)]
+  enable_8_bit: bool,
 
   /// Output .pco path to write to.
   pub path: PathBuf,

--- a/pco_cli/src/compress/mod.rs
+++ b/pco_cli/src/compress/mod.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use clap::Parser;
 
 use crate::input::{InputColumnOpt, InputFileOpt};
-use crate::parse;
 use crate::{arrow_handlers, chunk_config_opt, input, utils};
 
 pub mod handler;

--- a/pco_cli/src/dtypes.rs
+++ b/pco_cli/src/dtypes.rs
@@ -8,6 +8,9 @@ use pco::data_types::{Number, NumberType};
 
 use crate::num_vec::NumVec;
 
+#[derive(Clone, Debug)]
+pub struct ArrowDataTypes(pub Vec<ArrowDataType>);
+
 pub trait Parquetable: Sized {
   const PARQUET_DTYPE_STR: &'static str;
   const TRANSMUTABLE: bool = true;
@@ -420,5 +423,72 @@ pub fn to_arrow(dtype: NumberType) -> ArrowDataType {
       "number type {:?} not yet supported in pco_cli",
       other
     ),
+  }
+}
+
+pub fn all_arrow() -> ArrowDataTypes {
+  ArrowDataTypes(vec![
+    ArrowDataType::Float16,
+    ArrowDataType::Float32,
+    ArrowDataType::Float64,
+    ArrowDataType::Int8,
+    ArrowDataType::Int16,
+    ArrowDataType::Int32,
+    ArrowDataType::Int64,
+    ArrowDataType::UInt8,
+    ArrowDataType::UInt16,
+    ArrowDataType::UInt32,
+    ArrowDataType::UInt64,
+    ArrowDataType::Timestamp(arrow_dtypes::TimeUnit::Second, None),
+    ArrowDataType::Timestamp(arrow_dtypes::TimeUnit::Millisecond, None),
+    ArrowDataType::Timestamp(arrow_dtypes::TimeUnit::Microsecond, None),
+    ArrowDataType::Timestamp(arrow_dtypes::TimeUnit::Nanosecond, None),
+    ArrowDataType::Date32,
+    ArrowDataType::Date64,
+  ])
+}
+
+pub fn all_arrow_except_8_bit() -> ArrowDataTypes {
+  ArrowDataTypes(
+    all_arrow()
+      .0
+      .into_iter()
+      .filter(|dtype| *dtype != ArrowDataType::Int8 && *dtype != ArrowDataType::UInt8)
+      .collect(),
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_all_pco_dtypes_are_arrowable() {
+    for i in 0..=255 {
+      match pco::data_types::NumberType::from_descriminant(i) {
+        Some(dtype) => {
+          let arrow_dtype = to_arrow(dtype);
+          assert_eq!(from_arrow(&arrow_dtype).unwrap(), dtype);
+        }
+        None => continue,
+      }
+    }
+  }
+
+  #[test]
+  fn test_all_pco_dtypes_except_8_bit_in_default_list() {
+    let arrow_dtypes_except_8_bit = all_arrow_except_8_bit().0;
+    for i in 0..=255 {
+      match pco::data_types::NumberType::from_descriminant(i) {
+        Some(dtype) => {
+          if dtype == NumberType::U8 || dtype == NumberType::I8 {
+            continue;
+          }
+          let arrow_dtype = to_arrow(dtype);
+          assert!(arrow_dtypes_except_8_bit.contains(&arrow_dtype));
+        }
+        None => continue,
+      }
+    }
   }
 }

--- a/pco_cli/src/dtypes.rs
+++ b/pco_cli/src/dtypes.rs
@@ -8,6 +8,7 @@ use pco::data_types::{Number, NumberType};
 
 use crate::num_vec::NumVec;
 
+// newtype so that clap doesn't try to parse the vec elems individually
 #[derive(Clone, Debug)]
 pub struct ArrowDataTypes(pub Vec<ArrowDataType>);
 

--- a/pco_cli/src/parse.rs
+++ b/pco_cli/src/parse.rs
@@ -3,6 +3,8 @@ use arrow::datatypes::{DataType, TimeUnit};
 
 use pco::{DeltaSpec, ModeSpec};
 
+use crate::dtypes::{self, ArrowDataTypes};
+
 pub fn delta_spec(s: &str) -> anyhow::Result<DeltaSpec> {
   let spec = match s.to_lowercase().as_str() {
     "auto" => DeltaSpec::Auto,
@@ -92,13 +94,16 @@ pub fn arrow_dtype(s: &str) -> anyhow::Result<DataType> {
   ))
 }
 
-pub fn boolean(s: &str) -> anyhow::Result<bool> {
+pub fn arrow_dtypes(s: &str) -> anyhow::Result<ArrowDataTypes> {
   match s.to_lowercase().as_str() {
-    "0" | "f" | "n" | "false" => Ok(false),
-    "1" | "t" | "y" | "true" => Ok(true),
-    _ => Err(anyhow!(
-      "unable to parse boolean: {}. try 't' or 'f'",
-      s
-    )),
+    "all_except_8_bit" => return Ok(dtypes::all_arrow_except_8_bit()),
+    "all_including_8_bit" => return Ok(dtypes::all_arrow()),
+    _ => {}
   }
+
+  let mut res = vec![];
+  for s in s.split(",") {
+    res.push(arrow_dtype(s)?);
+  }
+  Ok(ArrowDataTypes(res))
 }


### PR DESCRIPTION
Before:

```bash
pcodec compress -i i8_foo.bin out.pco --enable-8-bit=t
pcodec bench -i i8_foo.bin -c pco:enable-8-bit=t
```

After:

```bash
pcodec compress -i i8_foo.bin out.pco --enable-8-bit
pcodec bench -i i8_foo.bin --dtypes all_including_8_bit
```

Things this makes nicer:
* Bench won't error on a dataset including 8-bit data types by default anymore; will just filter to relevant dtypes.
* It never really made sense before that you would want some codecs to support 8 bit and others not; top-level makes a lot more sense