### PR TITLE
Build `pco_c` as both `cdylib` and `staticlib`

### DIFF
--- a/pco_c/Cargo.toml
+++ b/pco_c/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [lib]
 name = "cpcodec"
-crate-type = ["dylib"]
+crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 half = { workspace = true, features = ["std"] }


### PR DESCRIPTION
So that consumers can pick either. Nb. the old version was built as `dylib`, but `cdylib` is what you're supposed to use in a C library.