### PR TITLE
Fix five decoder/API defects found by fuzzing and Kani

### DIFF
--- a/pco/src/compression_intermediates.rs
+++ b/pco/src/compression_intermediates.rs
@@ -1,6 +1,7 @@
 use crate::ans::{AnsState, Symbol};
 use crate::constants::{Bitlen, Weight, ANS_INTERLEAVING};
-use crate::data_types::{Latent, Number, SplitLatents};
+use crate::data_types::number_priv::NumberPriv;
+use crate::data_types::{Latent, SplitLatents};
 use crate::delta::DeltaState;
 use crate::metadata::per_latent_var::{LatentVarKey, PerLatentVar};
 use crate::metadata::{DynLatents, Mode};
@@ -65,7 +66,7 @@ impl<L: Latent> Default for BinCompressionInfo<L> {
 }
 
 #[allow(clippy::type_complexity)]
-pub struct Bid<T: Number> {
+pub struct Bid<T: NumberPriv> {
   pub mode: Mode,
   pub bits_saved_per_num: f64,
   // we include a split_fn since modes like FloatMult can benefit from extra
@@ -73,6 +74,13 @@ pub struct Bid<T: Number> {
   // information is an implementation detail of the compressor, not part of the
   // format itself, and is not / does not need to be known to the decompressor.
   pub split_fn: Box<dyn FnOnce(&[T]) -> SplitLatents>,
+}
+
+pub fn choose_winning_bid<T: NumberPriv>(bids: Vec<Bid<T>>) -> Bid<T> {
+  bids
+    .into_iter()
+    .max_by(|bid0, bid1| bid0.bits_saved_per_num.total_cmp(&bid1.bits_saved_per_num))
+    .expect("bids must be nonempty")
 }
 
 #[derive(Default)]

--- a/pco/src/constants.rs
+++ b/pco/src/constants.rs
@@ -37,11 +37,11 @@ pub const MAX_CONSECUTIVE_DELTA_ORDER: usize = 7;
 pub const MAX_CONV1_DELTA_ORDER: usize = 32;
 pub const MAX_CONV1_DELTA_QUANTIZATION: Bitlen = (1 << BITS_TO_ENCODE_DELTA_CONV_QUANTIZATION) - 1;
 pub const MAX_ENTRIES: usize = 1 << 24;
-// The wire format allows a lookback window_n_log of up to 32, but the window
-// buffer is allocated eagerly on read, so we cap what we accept. This leaves
-// room for encoders to grow beyond LOOKBACK_MAX_WINDOW_N_LOG while keeping the
-// buffer well under a GB: no chunk can hold more than MAX_ENTRIES numbers
-// anyway, so a larger window could never be fully used.
+// The window_n_log field on the wire is wider than any window we are willing to
+// allocate on read, so reads are capped here. This is deliberately looser than
+// what the encoder emits (ENCODING_LOOKBACK_MAX_WINDOW_N_LOG), leaving room for
+// future encoders; a chunk can hold no more than MAX_ENTRIES numbers, so a
+// larger window could never be fully used anyway.
 pub const MAX_DELTA_LOOKBACK_WINDOW_N_LOG: Bitlen = MAX_ENTRIES.ilog2() as Bitlen;
 pub const MAX_SUPPORTED_PRECISION: Bitlen = 128;
 pub const MAX_SUPPORTED_PRECISION_BYTES: usize = (MAX_SUPPORTED_PRECISION / 8) as usize;

--- a/pco/src/constants.rs
+++ b/pco/src/constants.rs
@@ -37,6 +37,12 @@ pub const MAX_CONSECUTIVE_DELTA_ORDER: usize = 7;
 pub const MAX_CONV1_DELTA_ORDER: usize = 32;
 pub const MAX_CONV1_DELTA_QUANTIZATION: Bitlen = (1 << BITS_TO_ENCODE_DELTA_CONV_QUANTIZATION) - 1;
 pub const MAX_ENTRIES: usize = 1 << 24;
+// The wire format allows a lookback window_n_log of up to 32, but the window
+// buffer is allocated eagerly on read, so we cap what we accept. This leaves
+// room for encoders to grow beyond LOOKBACK_MAX_WINDOW_N_LOG while keeping the
+// buffer well under a GB: no chunk can hold more than MAX_ENTRIES numbers
+// anyway, so a larger window could never be fully used.
+pub const MAX_DELTA_LOOKBACK_WINDOW_N_LOG: Bitlen = MAX_ENTRIES.ilog2() as Bitlen;
 pub const MAX_SUPPORTED_PRECISION: Bitlen = 128;
 pub const MAX_SUPPORTED_PRECISION_BYTES: usize = (MAX_SUPPORTED_PRECISION / 8) as usize;
 pub const MULT_REQUIRED_BITS_SAVED_PER_NUM: f64 = 0.5;

--- a/pco/src/data_types/float.rs
+++ b/pco/src/data_types/float.rs
@@ -1,6 +1,5 @@
 use half::f16;
 
-use super::ModeAndLatents;
 use crate::chunk_config::ModeSpec;
 use crate::compression_intermediates::Bid;
 use crate::constants::Bitlen;
@@ -80,67 +79,56 @@ fn filter_sample<F: Float>(num: &F) -> Option<F> {
   None
 }
 
-fn choose_mode_and_split_latents<F: Float>(
-  nums: &[F],
-  chunk_config: &ChunkConfig,
-) -> PcoResult<ModeAndLatents> {
-  match chunk_config.mode_spec {
+fn choose_mode_bids<F: Float>(nums: &[F], chunk_config: &ChunkConfig) -> PcoResult<Vec<Bid<F>>> {
+  let bids = match chunk_config.mode_spec {
     ModeSpec::Auto => {
       // up to 3 bids: classic, float mult, float quant modes
-      let mut bids: Vec<Bid<F>> = vec![];
-      bids.push(Bid {
+      let mut bids: Vec<Bid<F>> = vec![Bid {
         mode: Mode::Classic,
         bits_saved_per_num: 0.0,
         split_fn: Box::new(|nums| classic::split_latents(nums)),
-      });
+      }];
 
       if let Some(sample) = sampling::choose_sample(nums, filter_sample) {
         bids.extend(float_mult::compute_bid(&sample));
         bids.extend(float_quant::compute_bid(&sample));
       }
 
-      let winning_bid = choose_winning_bid(bids);
-      let latents = (winning_bid.split_fn)(nums);
-      Ok((winning_bid.mode, latents))
+      bids
     }
-    ModeSpec::Classic => Ok((Mode::Classic, classic::split_latents(nums))),
+    ModeSpec::Classic => vec![Bid {
+      mode: Mode::Classic,
+      bits_saved_per_num: 0.0,
+      split_fn: Box::new(|nums| classic::split_latents(nums)),
+    }],
     ModeSpec::TryFloatMult(base_f64) => {
       let base = F::from_f64(base_f64);
-      let mode = Mode::float_mult(base);
       let float_mult_config = FloatMultConfig {
         base,
         inv_base: base.inv(),
       };
-      let latents = float_mult::split_latents(nums, float_mult_config);
-      Ok((mode, latents))
+      vec![Bid {
+        mode: Mode::float_mult(base),
+        bits_saved_per_num: 0.0,
+        split_fn: Box::new(move |nums| float_mult::split_latents(nums, float_mult_config)),
+      }]
     }
-    ModeSpec::TryFloatQuant(k) => {
-      // Must be checked before splitting: split_latents shifts by `k`.
-      if k >= F::L::BITS {
-        return Err(PcoError::invalid_argument(format!(
-          "float quantization k of {} must be less than the type's {} bits",
-          k,
-          F::L::BITS,
-        )));
-      }
-      Ok((
-        Mode::FloatQuant(k),
-        float_quant::split_latents(nums, k),
+    ModeSpec::TryFloatQuant(k) => vec![Bid {
+      mode: Mode::FloatQuant(k),
+      bits_saved_per_num: 0.0,
+      // Note that this is only invoked after the mode is validated; k is a
+      // shift width, so splitting with an out-of-range one is UB-adjacent.
+      split_fn: Box::new(move |nums| float_quant::split_latents(nums, k)),
+    }],
+    ModeSpec::TryIntMult(_) => {
+      return Err(PcoError::invalid_argument(
+        "unable to use int mult mode on floats",
       ))
     }
-    ModeSpec::TryIntMult(_) => Err(PcoError::invalid_argument(
-      "unable to use int mult mode on floats",
-    )),
-    ModeSpec::TryDict => dict::configure_and_split_latents(nums),
-  }
-}
+    ModeSpec::TryDict => vec![dict::compute_bid(nums)],
+  };
 
-// one day we might reuse this for int modes
-fn choose_winning_bid<T: Number>(bids: Vec<Bid<T>>) -> Bid<T> {
-  bids
-    .into_iter()
-    .max_by(|bid0, bid1| bid0.bits_saved_per_num.total_cmp(&bid1.bits_saved_per_num))
-    .expect("bids must be nonempty")
+  Ok(bids)
 }
 
 macro_rules! impl_float {
@@ -396,11 +384,8 @@ macro_rules! impl_float_number {
           Mode::IntMult(_) => false,
         }
       }
-      fn choose_mode_and_split_latents(
-        nums: &[Self],
-        config: &ChunkConfig,
-      ) -> PcoResult<ModeAndLatents> {
-        choose_mode_and_split_latents(nums, config)
+      fn choose_mode_bids(nums: &[Self], config: &ChunkConfig) -> PcoResult<Vec<Bid<Self>>> {
+        choose_mode_bids(nums, config)
       }
 
       #[inline]
@@ -463,13 +448,19 @@ impl_float_number!(f16, u16, 1_u16 << 15, 9);
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::compression_intermediates::choose_winning_bid;
   use crate::metadata::{DynLatent, DynLatents};
+
+  fn choose_mode<F: Float>(nums: &[F]) -> Mode {
+    let bids = choose_mode_bids(nums, &ChunkConfig::default()).unwrap();
+    choose_winning_bid(bids).mode
+  }
 
   #[test]
   fn test_choose_mult_mode() {
     let base = 1.5;
     let nums = (0..1000).map(|i| (i as f64) * base).collect::<Vec<_>>();
-    let (mode, _) = choose_mode_and_split_latents(&nums, &ChunkConfig::default()).unwrap();
+    let mode = choose_mode(&nums);
     assert_eq!(mode, Mode::float_mult(base));
     assert!(f64::mode_is_valid(&mode))
   }
@@ -525,7 +516,7 @@ mod tests {
     let nums = (0..1000)
       .map(|i| f64::from_bits(lowest_num_bits + (i << k)))
       .collect::<Vec<_>>();
-    let (mode, _) = choose_mode_and_split_latents(&nums, &ChunkConfig::default()).unwrap();
+    let mode = choose_mode(&nums);
     assert_eq!(mode, Mode::FloatQuant(k));
   }
 

--- a/pco/src/data_types/float.rs
+++ b/pco/src/data_types/float.rs
@@ -114,10 +114,20 @@ fn choose_mode_and_split_latents<F: Float>(
       let latents = float_mult::split_latents(nums, float_mult_config);
       Ok((mode, latents))
     }
-    ModeSpec::TryFloatQuant(k) => Ok((
-      Mode::FloatQuant(k),
-      float_quant::split_latents(nums, k),
-    )),
+    ModeSpec::TryFloatQuant(k) => {
+      // Must be checked before splitting: split_latents shifts by `k`.
+      if k >= F::L::BITS {
+        return Err(PcoError::invalid_argument(format!(
+          "float quantization k of {} must be less than the type's {} bits",
+          k,
+          F::L::BITS,
+        )));
+      }
+      Ok((
+        Mode::FloatQuant(k),
+        float_quant::split_latents(nums, k),
+      ))
+    }
     ModeSpec::TryIntMult(_) => Err(PcoError::invalid_argument(
       "unable to use int mult mode on floats",
     )),

--- a/pco/src/data_types/latent_priv.rs
+++ b/pco/src/data_types/latent_priv.rs
@@ -56,6 +56,7 @@ pub trait LatentPriv:
 
   fn wrapping_add(self, other: Self) -> Self;
   fn wrapping_sub(self, other: Self) -> Self;
+  fn wrapping_mul(self, other: Self) -> Self;
 
   fn toggle_center(self) -> Self {
     self.wrapping_add(Self::MID)

--- a/pco/src/data_types/mod.rs
+++ b/pco/src/data_types/mod.rs
@@ -5,7 +5,7 @@ use crate::data_types::latent_priv::LatentPriv;
 use crate::data_types::number_priv::NumberPriv;
 use crate::describers::LatentDescriber;
 use crate::metadata::per_latent_var::PerLatentVar;
-use crate::metadata::{ChunkMeta, Mode};
+use crate::metadata::ChunkMeta;
 
 mod dynamic;
 pub(crate) mod float;
@@ -14,8 +14,6 @@ pub(crate) mod number_priv;
 pub(crate) mod signed;
 mod split_latents;
 pub(crate) mod unsigned;
-
-pub(crate) type ModeAndLatents = (Mode, SplitLatents);
 
 /// Trait for types that behave like unsigned integers.
 ///

--- a/pco/src/data_types/number_priv.rs
+++ b/pco/src/data_types/number_priv.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display};
 
+use crate::compression_intermediates::Bid;
 use crate::data_types::latent_priv::LatentPriv;
-use crate::data_types::ModeAndLatents;
 use crate::dyn_slices::DynLatentSlice;
 use crate::errors::PcoResult;
 use crate::metadata::Mode;
@@ -23,18 +23,18 @@ pub trait NumberPriv: Copy + Debug + Display + Default + PartialEq + Send + Sync
   type L: LatentPriv;
 
   fn mode_is_valid(mode: &Mode) -> bool;
-  /// Breaks the numbers into latent variables for better compression.
+  /// Proposes the modes worth considering for these numbers.
   ///
-  /// Returns
-  /// * mode: the [`Mode`] that will be stored alongside the data
+  /// Each [`Bid`] carries
+  /// * mode: the [`Mode`] that would be stored alongside the data
   ///   for decompression
-  /// * latents: a primary and optionally secondary latent variable, each of
-  ///   which contains a latent per num in `nums`. Primary must be of the same
-  ///   latent type as T.
-  fn choose_mode_and_split_latents(
-    nums: &[Self],
-    config: &ChunkConfig,
-  ) -> PcoResult<ModeAndLatents>;
+  /// * split_fn: breaks the numbers into a primary and optionally secondary
+  ///   latent variable, each of which contains a latent per num in `nums`.
+  ///   Primary must be of the same latent type as T.
+  ///
+  /// The caller picks the winning bid and validates its mode before invoking
+  /// `split_fn`, so `split_fn` may assume the mode is valid for this type.
+  fn choose_mode_bids(nums: &[Self], config: &ChunkConfig) -> PcoResult<Vec<Bid<Self>>>;
 
   fn from_latent_ordered(l: Self::L) -> Self;
   fn to_latent_ordered(self) -> Self::L;

--- a/pco/src/data_types/signed.rs
+++ b/pco/src/data_types/signed.rs
@@ -1,5 +1,6 @@
+use crate::compression_intermediates::Bid;
 use crate::constants::Bitlen;
-use crate::data_types::{unsigned, ModeAndLatents, Number, NumberPriv};
+use crate::data_types::{unsigned, Number, NumberPriv};
 use crate::describers::LatentDescriber;
 use crate::dyn_slices::DynLatentSlice;
 use crate::errors::PcoResult;
@@ -37,11 +38,8 @@ macro_rules! impl_signed {
       fn mode_is_valid(mode: &Mode) -> bool {
         unsigned::mode_is_valid::<Self::L>(mode)
       }
-      fn choose_mode_and_split_latents(
-        nums: &[Self],
-        config: &ChunkConfig,
-      ) -> PcoResult<ModeAndLatents> {
-        unsigned::choose_mode_and_split_latents(&nums, config)
+      fn choose_mode_bids(nums: &[Self], config: &ChunkConfig) -> PcoResult<Vec<Bid<Self>>> {
+        unsigned::choose_mode_bids(nums, config)
       }
 
       #[inline]

--- a/pco/src/data_types/unsigned.rs
+++ b/pco/src/data_types/unsigned.rs
@@ -108,6 +108,11 @@ macro_rules! impl_latent {
       }
 
       #[inline]
+      fn wrapping_mul(self, other: Self) -> Self {
+        self.wrapping_mul(other)
+      }
+
+      #[inline]
       fn wrapping_sub(self, other: Self) -> Self {
         self.wrapping_sub(other)
       }

--- a/pco/src/data_types/unsigned.rs
+++ b/pco/src/data_types/unsigned.rs
@@ -1,40 +1,49 @@
-use super::ModeAndLatents;
+use crate::compression_intermediates::Bid;
 use crate::constants::Bitlen;
 use crate::data_types::{Latent, LatentPriv, Number, NumberPriv};
 use crate::describers::LatentDescriber;
 use crate::dyn_slices::DynLatentSlice;
 use crate::errors::{PcoError, PcoResult};
 use crate::metadata::per_latent_var::PerLatentVar;
-use crate::metadata::{ChunkMeta, DynLatent, Mode};
+use crate::metadata::{ChunkMeta, Mode};
 use crate::mode::{classic, dict, int_mult};
 use crate::{describers, ChunkConfig, ModeSpec};
 
-pub fn choose_mode_and_split_latents<T: Number>(
-  nums: &[T],
-  config: &ChunkConfig,
-) -> PcoResult<ModeAndLatents> {
-  match config.mode_spec {
-    ModeSpec::Auto => {
-      if let Some(base) = int_mult::choose_base(nums) {
-        let mode = Mode::int_mult(base);
-        let latents = int_mult::split_latents(nums, base);
-        Ok((mode, latents))
-      } else {
-        Ok((Mode::Classic, classic::split_latents(nums)))
-      }
-    }
-    ModeSpec::Classic => Ok((Mode::Classic, classic::split_latents(nums))),
-    ModeSpec::TryFloatMult(_) | ModeSpec::TryFloatQuant(_) => Err(PcoError::invalid_argument(
-      "unable to use float mode for ints",
-    )),
-    ModeSpec::TryIntMult(base_u64) => {
-      let base = T::L::from_u64(base_u64);
-      let mode = Mode::IntMult(DynLatent::new(base));
-      let latents = int_mult::split_latents(nums, base);
-      Ok((mode, latents))
-    }
-    ModeSpec::TryDict => dict::configure_and_split_latents(nums),
+fn classic_bid<T: Number>() -> Bid<T> {
+  Bid {
+    mode: Mode::Classic,
+    bits_saved_per_num: 0.0,
+    split_fn: Box::new(|nums| classic::split_latents(nums)),
   }
+}
+
+fn int_mult_bid<T: Number>(base: T::L) -> Bid<T> {
+  Bid {
+    mode: Mode::int_mult(base),
+    bits_saved_per_num: 0.0,
+    split_fn: Box::new(move |nums| int_mult::split_latents(nums, base)),
+  }
+}
+
+pub fn choose_mode_bids<T: Number>(nums: &[T], config: &ChunkConfig) -> PcoResult<Vec<Bid<T>>> {
+  let bids = match config.mode_spec {
+    ModeSpec::Auto => match int_mult::choose_base(nums) {
+      // int mult is only bid when it's already known to be worthwhile, so we
+      // don't offer classic alongside it
+      Some(base) => vec![int_mult_bid(base)],
+      None => vec![classic_bid()],
+    },
+    ModeSpec::Classic => vec![classic_bid()],
+    ModeSpec::TryFloatMult(_) | ModeSpec::TryFloatQuant(_) => {
+      return Err(PcoError::invalid_argument(
+        "unable to use float mode for ints",
+      ))
+    }
+    ModeSpec::TryIntMult(base_u64) => vec![int_mult_bid(T::L::from_u64(base_u64))],
+    ModeSpec::TryDict => vec![dict::compute_bid(nums)],
+  };
+
+  Ok(bids)
 }
 
 pub fn join_latents<T: Number>(
@@ -138,11 +147,8 @@ macro_rules! impl_unsigned_number {
       fn mode_is_valid(mode: &Mode) -> bool {
         mode_is_valid::<Self::L>(mode)
       }
-      fn choose_mode_and_split_latents(
-        nums: &[Self],
-        config: &ChunkConfig,
-      ) -> PcoResult<ModeAndLatents> {
-        choose_mode_and_split_latents(nums, config)
+      fn choose_mode_bids(nums: &[Self], config: &ChunkConfig) -> PcoResult<Vec<Bid<Self>>> {
+        choose_mode_bids(nums, config)
       }
 
       #[inline]

--- a/pco/src/delta/mod.rs
+++ b/pco/src/delta/mod.rs
@@ -13,8 +13,10 @@ use crate::metadata::dyn_latents::DynLatents;
 use crate::metadata::{DeltaEncoding, DeltaLookbackConfig};
 use std::ops::Range;
 
-const LOOKBACK_MAX_WINDOW_N_LOG: Bitlen = 15;
-const LOOKBACK_MIN_WINDOW_N_LOG: Bitlen = 4;
+// What the encoder is willing to emit; the reader accepts a looser bound (see
+// MAX_DELTA_LOOKBACK_WINDOW_N_LOG).
+const ENCODING_LOOKBACK_MAX_WINDOW_N_LOG: Bitlen = 15;
+const ENCODING_LOOKBACK_MIN_WINDOW_N_LOG: Bitlen = 4;
 
 pub type DeltaState = DynLatents;
 
@@ -36,8 +38,8 @@ pub fn new_lookback(n: usize) -> DeltaEncoding {
   DeltaEncoding::Lookback {
     config: DeltaLookbackConfig {
       window_n_log: bits::bits_to_encode_offset(n as u32 - 1).clamp(
-        LOOKBACK_MIN_WINDOW_N_LOG,
-        LOOKBACK_MAX_WINDOW_N_LOG,
+        ENCODING_LOOKBACK_MIN_WINDOW_N_LOG,
+        ENCODING_LOOKBACK_MAX_WINDOW_N_LOG,
       ),
       state_n_log: 0,
     },

--- a/pco/src/delta/mod.rs
+++ b/pco/src/delta/mod.rs
@@ -13,7 +13,7 @@ use crate::metadata::dyn_latents::DynLatents;
 use crate::metadata::{DeltaEncoding, DeltaLookbackConfig};
 use std::ops::Range;
 
-const LOOKBACK_MAX_WINDOW_N_LOG: Bitlen = 15;
+pub(crate) const LOOKBACK_MAX_WINDOW_N_LOG: Bitlen = 15;
 const LOOKBACK_MIN_WINDOW_N_LOG: Bitlen = 4;
 
 pub type DeltaState = DynLatents;

--- a/pco/src/delta/mod.rs
+++ b/pco/src/delta/mod.rs
@@ -13,7 +13,7 @@ use crate::metadata::dyn_latents::DynLatents;
 use crate::metadata::{DeltaEncoding, DeltaLookbackConfig};
 use std::ops::Range;
 
-pub(crate) const LOOKBACK_MAX_WINDOW_N_LOG: Bitlen = 15;
+const LOOKBACK_MAX_WINDOW_N_LOG: Bitlen = 15;
 const LOOKBACK_MIN_WINDOW_N_LOG: Bitlen = 4;
 
 pub type DeltaState = DynLatents;

--- a/pco/src/metadata/delta_encoding.rs
+++ b/pco/src/metadata/delta_encoding.rs
@@ -154,6 +154,16 @@ impl DeltaEncoding {
       2 => {
         let window_n_log = 1 + reader.read_bitlen(BITS_TO_ENCODE_DELTA_LOOKBACK_WINDOW_N_LOG);
         let state_n_log = reader.read_bitlen(BITS_TO_ENCODE_DELTA_LOOKBACK_STATE_N_LOG);
+        // The window buffer is allocated as max(1 << window_n_log, 256) * 2
+        // latents, so an unbounded value here is an allocation the input does
+        // not justify. The encoder never emits more than this.
+        if window_n_log > crate::delta::LOOKBACK_MAX_WINDOW_N_LOG {
+          return Err(PcoError::corruption(format!(
+            "LZ delta encoding window size log of {} exceeds max of {}",
+            window_n_log,
+            crate::delta::LOOKBACK_MAX_WINDOW_N_LOG,
+          )));
+        }
         if state_n_log > window_n_log {
           return Err(PcoError::corruption(format!(
             "LZ delta encoding state size log exceeded window size log: {} vs {}",

--- a/pco/src/metadata/delta_encoding.rs
+++ b/pco/src/metadata/delta_encoding.rs
@@ -313,6 +313,53 @@ mod tests {
   use super::*;
   use crate::bit_writer::BitWriter;
 
+  // The window buffer is sized `max(1 << window_n_log, 256) * 2` latents, so
+  // an out-of-range `window_n_log` off the wire is an allocation the file has
+  // not earned (`window_n_log = 32` is 64 GiB for i64). The 5 bits on the wire
+  // admit up to 32; the encoder never emits more than
+  // LOOKBACK_MAX_WINDOW_N_LOG, so reads above that must be rejected.
+  #[test]
+  fn test_oversized_lookback_window_is_rejected() {
+    for window_n_log in [
+      crate::delta::LOOKBACK_MAX_WINDOW_N_LOG,
+      crate::delta::LOOKBACK_MAX_WINDOW_N_LOG + 1,
+      24,
+      32,
+    ] {
+      let encoding = DeltaEncoding::Lookback {
+        config: DeltaLookbackConfig {
+          window_n_log,
+          state_n_log: 0,
+        },
+        secondary_uses_delta: false,
+      };
+      let mut bytes = Vec::new();
+      let mut writer = BitWriter::new(&mut bytes, DeltaEncoding::MAX_BIT_SIZE);
+      unsafe { encoding.write_to(&mut writer) };
+      writer.finish_byte();
+      writer.flush().unwrap();
+      bytes.resize(bytes.len() + OVERSHOOT_PADDING, 0);
+
+      let mut reader = BitReader::new(&bytes, bytes.len(), 0);
+      let res = unsafe { DeltaEncoding::read_from(&mut reader, &FormatVersion::max_supported()) };
+
+      if window_n_log <= crate::delta::LOOKBACK_MAX_WINDOW_N_LOG {
+        assert_eq!(
+          res.unwrap(),
+          encoding,
+          "window_n_log={} should round trip",
+          window_n_log
+        );
+      } else {
+        assert!(
+          res.is_err(),
+          "window_n_log={} should be rejected",
+          window_n_log
+        );
+      }
+    }
+  }
+
   fn check_bit_size(encoding: DeltaEncoding) {
     let mut bytes = Vec::new();
     let mut writer = BitWriter::new(

--- a/pco/src/metadata/delta_encoding.rs
+++ b/pco/src/metadata/delta_encoding.rs
@@ -154,9 +154,8 @@ impl DeltaEncoding {
       2 => {
         let window_n_log = 1 + reader.read_bitlen(BITS_TO_ENCODE_DELTA_LOOKBACK_WINDOW_N_LOG);
         let state_n_log = reader.read_bitlen(BITS_TO_ENCODE_DELTA_LOOKBACK_STATE_N_LOG);
-        // The window buffer is allocated as max(1 << window_n_log, 256) * 2
-        // latents, so an unbounded value here is an allocation the file has
-        // not earned.
+        // The window buffer is allocated from this, so an unbounded value here
+        // is an allocation the file has not earned.
         if window_n_log > MAX_DELTA_LOOKBACK_WINDOW_N_LOG {
           return Err(PcoError::corruption(format!(
             "LZ delta encoding window size log of {} exceeds max of {}",
@@ -312,21 +311,9 @@ mod tests {
   use super::*;
   use crate::bit_writer::BitWriter;
 
-  // The window buffer is sized `max(1 << window_n_log, 256) * 2` latents, so
-  // an out-of-range `window_n_log` off the wire is an allocation the file has
-  // not earned (`window_n_log = 32` is 64 GiB for i64). The 5 bits on the wire
-  // admit up to 32, so reads above MAX_DELTA_LOOKBACK_WINDOW_N_LOG must be
-  // rejected.
   #[test]
   fn test_oversized_lookback_window_is_rejected() {
-    for window_n_log in [
-      1,
-      15,
-      MAX_DELTA_LOOKBACK_WINDOW_N_LOG,
-      MAX_DELTA_LOOKBACK_WINDOW_N_LOG + 1,
-      31,
-      32,
-    ] {
+    for window_n_log in [MAX_DELTA_LOOKBACK_WINDOW_N_LOG + 1, 31, 32] {
       let encoding = DeltaEncoding::Lookback {
         config: DeltaLookbackConfig {
           window_n_log,
@@ -344,20 +331,11 @@ mod tests {
       let mut reader = BitReader::new(&bytes, bytes.len(), 0);
       let res = unsafe { DeltaEncoding::read_from(&mut reader, &FormatVersion::max_supported()) };
 
-      if window_n_log <= MAX_DELTA_LOOKBACK_WINDOW_N_LOG {
-        assert_eq!(
-          res.unwrap(),
-          encoding,
-          "window_n_log={} should round trip",
-          window_n_log
-        );
-      } else {
-        assert!(
-          res.is_err(),
-          "window_n_log={} should be rejected",
-          window_n_log
-        );
-      }
+      assert!(
+        res.is_err(),
+        "window_n_log={} should be rejected",
+        window_n_log
+      );
     }
   }
 

--- a/pco/src/metadata/delta_encoding.rs
+++ b/pco/src/metadata/delta_encoding.rs
@@ -155,13 +155,12 @@ impl DeltaEncoding {
         let window_n_log = 1 + reader.read_bitlen(BITS_TO_ENCODE_DELTA_LOOKBACK_WINDOW_N_LOG);
         let state_n_log = reader.read_bitlen(BITS_TO_ENCODE_DELTA_LOOKBACK_STATE_N_LOG);
         // The window buffer is allocated as max(1 << window_n_log, 256) * 2
-        // latents, so an unbounded value here is an allocation the input does
-        // not justify. The encoder never emits more than this.
-        if window_n_log > crate::delta::LOOKBACK_MAX_WINDOW_N_LOG {
+        // latents, so an unbounded value here is an allocation the file has
+        // not earned.
+        if window_n_log > MAX_DELTA_LOOKBACK_WINDOW_N_LOG {
           return Err(PcoError::corruption(format!(
             "LZ delta encoding window size log of {} exceeds max of {}",
-            window_n_log,
-            crate::delta::LOOKBACK_MAX_WINDOW_N_LOG,
+            window_n_log, MAX_DELTA_LOOKBACK_WINDOW_N_LOG,
           )));
         }
         if state_n_log > window_n_log {
@@ -316,14 +315,16 @@ mod tests {
   // The window buffer is sized `max(1 << window_n_log, 256) * 2` latents, so
   // an out-of-range `window_n_log` off the wire is an allocation the file has
   // not earned (`window_n_log = 32` is 64 GiB for i64). The 5 bits on the wire
-  // admit up to 32; the encoder never emits more than
-  // LOOKBACK_MAX_WINDOW_N_LOG, so reads above that must be rejected.
+  // admit up to 32, so reads above MAX_DELTA_LOOKBACK_WINDOW_N_LOG must be
+  // rejected.
   #[test]
   fn test_oversized_lookback_window_is_rejected() {
     for window_n_log in [
-      crate::delta::LOOKBACK_MAX_WINDOW_N_LOG,
-      crate::delta::LOOKBACK_MAX_WINDOW_N_LOG + 1,
-      24,
+      1,
+      15,
+      MAX_DELTA_LOOKBACK_WINDOW_N_LOG,
+      MAX_DELTA_LOOKBACK_WINDOW_N_LOG + 1,
+      31,
       32,
     ] {
       let encoding = DeltaEncoding::Lookback {
@@ -343,7 +344,7 @@ mod tests {
       let mut reader = BitReader::new(&bytes, bytes.len(), 0);
       let res = unsafe { DeltaEncoding::read_from(&mut reader, &FormatVersion::max_supported()) };
 
-      if window_n_log <= crate::delta::LOOKBACK_MAX_WINDOW_N_LOG {
+      if window_n_log <= MAX_DELTA_LOOKBACK_WINDOW_N_LOG {
         assert_eq!(
           res.unwrap(),
           encoding,

--- a/pco/src/mode/dict.rs
+++ b/pco/src/mode/dict.rs
@@ -1,12 +1,13 @@
 use std::cmp;
 use std::collections::HashMap;
 
-use crate::data_types::{Latent, ModeAndLatents, Number, SplitLatents};
+use crate::compression_intermediates::Bid;
+use crate::data_types::{Latent, Number, SplitLatents};
 use crate::dyn_slices::DynLatentSlice;
 use crate::errors::{PcoError, PcoResult};
 use crate::metadata::{DynLatents, Mode};
 
-fn configure_less_specialized<L: Latent>(classic_nums: Vec<L>) -> PcoResult<ModeAndLatents> {
+fn configure_less_specialized<L: Latent>(classic_nums: Vec<L>) -> (Mode, SplitLatents) {
   let mut count_by_unique = HashMap::new();
   for &num in &classic_nums {
     *count_by_unique.entry(num).or_insert(0_u32) += 1;
@@ -41,21 +42,29 @@ fn configure_less_specialized<L: Latent>(classic_nums: Vec<L>) -> PcoResult<Mode
     .map(|num| *dict_idx_by_unique.get(&num.to_latent_ordered()).unwrap())
     .collect();
   let latents = DynLatents::U32(indices);
-  Ok((
+  (
     mode,
     SplitLatents {
       primary: latents,
       secondary: None,
     },
-  ))
+  )
 }
 
-pub fn configure_and_split_latents<T: Number>(nums: &[T]) -> PcoResult<ModeAndLatents> {
+/// Unlike other modes, dict has to build its dictionary from all the numbers,
+/// which produces the latents as a byproduct. We keep them in the split_fn so
+/// that the bid interface stays uniform.
+pub fn compute_bid<T: Number>(nums: &[T]) -> Bid<T> {
   let classic_nums = nums
     .iter()
     .map(|&num| num.to_latent_ordered())
     .collect::<Vec<_>>();
-  configure_less_specialized(classic_nums)
+  let (mode, latents) = configure_less_specialized(classic_nums);
+  Bid {
+    mode,
+    bits_saved_per_num: 0.0,
+    split_fn: Box::new(move |_nums| latents),
+  }
 }
 
 pub fn join_latents<T: Number>(

--- a/pco/src/mode/float_quant.rs
+++ b/pco/src/mode/float_quant.rs
@@ -4,7 +4,7 @@ use crate::data_types::float::Float;
 use crate::data_types::latent_priv::LatentPriv;
 use crate::data_types::SplitLatents;
 use crate::dyn_slices::DynLatentSlice;
-use crate::errors::PcoResult;
+use crate::errors::{PcoError, PcoResult};
 use crate::metadata::{DynLatents, Mode};
 use crate::sampling::{self, PrimaryLatentAndSavings};
 use std::cmp;
@@ -23,10 +23,12 @@ pub(crate) fn join_latents<F: Float>(
   let sign_cutoff = F::L::MID >> k;
   let lowest_k_bits_max = (F::L::ONE << k) - F::L::ONE;
   for ((&y, &m), dst) in primary.iter().zip(secondary.iter()).zip(dst.iter_mut()) {
-    debug_assert!(
-      m >> k == F::L::ZERO,
-      "Invalid input to FloatQuant: m must be a k-bit integer"
-    );
+    // `m` comes off the wire, so this is a corruption check, not an assertion.
+    if m >> k != F::L::ZERO {
+      return Err(PcoError::corruption(
+        "invalid FloatQuant secondary latent: m must be a k-bit integer",
+      ));
+    }
     let is_pos_as_float = y >= sign_cutoff;
     let lowest_k_bits = if is_pos_as_float {
       m

--- a/pco/src/mode/float_quant.rs
+++ b/pco/src/mode/float_quant.rs
@@ -4,7 +4,7 @@ use crate::data_types::float::Float;
 use crate::data_types::latent_priv::LatentPriv;
 use crate::data_types::SplitLatents;
 use crate::dyn_slices::DynLatentSlice;
-use crate::errors::{PcoError, PcoResult};
+use crate::errors::PcoResult;
 use crate::metadata::{DynLatents, Mode};
 use crate::sampling::{self, PrimaryLatentAndSavings};
 use std::cmp;
@@ -23,19 +23,16 @@ pub(crate) fn join_latents<F: Float>(
   let sign_cutoff = F::L::MID >> k;
   let lowest_k_bits_max = (F::L::ONE << k) - F::L::ONE;
   for ((&y, &m), dst) in primary.iter().zip(secondary.iter()).zip(dst.iter_mut()) {
-    // `m` comes off the wire, so this is a corruption check, not an assertion.
-    if m >> k != F::L::ZERO {
-      return Err(PcoError::corruption(
-        "invalid FloatQuant secondary latent: m must be a k-bit integer",
-      ));
-    }
     let is_pos_as_float = y >= sign_cutoff;
+    // `m` is untrusted, so it may exceed k bits, in which case this wraps and
+    // we decode to garbage (but never panic). Our own compressor only ever
+    // emits k-bit `m`s; see the debug assertion in `split_latents`.
     let lowest_k_bits = if is_pos_as_float {
       m
     } else {
-      lowest_k_bits_max - m
+      lowest_k_bits_max.wrapping_sub(m)
     };
-    *dst = F::from_latent_ordered((y << k) + lowest_k_bits);
+    *dst = F::from_latent_ordered((y << k).wrapping_add(lowest_k_bits));
   }
 
   Ok(())
@@ -54,11 +51,17 @@ pub(crate) fn split_latents<F: Float>(page_nums: &[F], k: Bitlen) -> SplitLatent
     // In the common case where `num` is exactly quantized, we want the secondary to always be
     // zero.  But when `num` is negative, `lowest_k_bits == lowest_k_bits_max`.  So we manually
     // flip it here, and un-flip it in `join_latents`.
-    secondary.push(if num.is_sign_positive_() {
+    let secondary_latent = if num.is_sign_positive_() {
       lowest_k_bits
     } else {
       lowest_k_bits_max - lowest_k_bits
-    });
+    };
+    // `join_latents` relies on this, so it's worth asserting that we uphold it
+    debug_assert!(
+      secondary_latent >> k == F::L::ZERO,
+      "Invalid FloatQuant secondary latent: m must be a k-bit integer"
+    );
+    secondary.push(secondary_latent);
   }
 
   SplitLatents {

--- a/pco/src/mode/int_mult.rs
+++ b/pco/src/mode/int_mult.rs
@@ -45,7 +45,9 @@ pub(crate) fn join_latents<T: Number>(
   let primary = primary.downcast::<T::L>().unwrap();
   let secondary = secondary.unwrap().downcast::<T::L>().unwrap();
   for ((&mult, &adj), dst) in primary.iter().zip(secondary.iter()).zip(dst.iter_mut()) {
-    *dst = T::from_latent_ordered((mult * base).wrapping_add(adj));
+    // Both operands come off the wire; the neighbouring add is already
+    // wrapping, so the multiply must be too.
+    *dst = T::from_latent_ordered(mult.wrapping_mul(base).wrapping_add(adj));
   }
 
   Ok(())

--- a/pco/src/standalone/constants.rs
+++ b/pco/src/standalone/constants.rs
@@ -7,6 +7,9 @@ pub const BITS_TO_ENCODE_N_ENTRIES: Bitlen = 24;
 pub const BITS_TO_ENCODE_STANDALONE_VERSION: Bitlen = 8;
 pub const BITS_TO_ENCODE_VARINT_POWER: Bitlen = 6;
 pub const CURRENT_STANDALONE_VERSION: usize = 3;
+// `n_hint` is untrusted, so we only preallocate this many numbers for it,
+// which is plenty to be performant even for outputs of several GB.
+pub const MAX_N_HINT_PREALLOC: usize = 1 << 30;
 
 // padding
 pub const STANDALONE_CHUNK_PREAMBLE_PADDING: usize =

--- a/pco/src/standalone/constants.rs
+++ b/pco/src/standalone/constants.rs
@@ -7,9 +7,14 @@ pub const BITS_TO_ENCODE_N_ENTRIES: Bitlen = 24;
 pub const BITS_TO_ENCODE_STANDALONE_VERSION: Bitlen = 8;
 pub const BITS_TO_ENCODE_VARINT_POWER: Bitlen = 6;
 pub const CURRENT_STANDALONE_VERSION: usize = 3;
-// `n_hint` is untrusted, so we only preallocate this many numbers for it,
-// which is plenty to be performant even for outputs of several GB.
-pub const MAX_N_HINT_PREALLOC: usize = 1 << 30;
+// `n_hint` is untrusted, so we only preallocate this many bytes for it by
+// default, which is plenty to be performant even for outputs of several GB.
+// Saturates on platforms whose usize is too narrow to hold it.
+pub const DEFAULT_MAX_PREALLOC_BYTES: usize = if (1_u64 << 32) <= usize::MAX as u64 {
+  (1_u64 << 32) as usize
+} else {
+  usize::MAX
+};
 
 // padding
 pub const STANDALONE_CHUNK_PREAMBLE_PADDING: usize =

--- a/pco/src/standalone/decompressor.rs
+++ b/pco/src/standalone/decompressor.rs
@@ -130,7 +130,7 @@ impl FileDecompressor {
         inner,
         uniform_type: uniform_number_type,
         n_hint,
-        max_prealloc_bytes: usize::MAX,
+        max_prealloc_bytes: DEFAULT_MAX_PREALLOC_BYTES,
       },
       rest,
     ))
@@ -140,7 +140,7 @@ impl FileDecompressor {
   /// on the file's `n_hint`.
   ///
   /// `n_hint` is untrusted - a tiny file may legally declare `usize::MAX` - so
-  /// it is always capped at `MAX_N_HINT_PREALLOC` numbers. Use this if you
+  /// it is capped at `DEFAULT_MAX_PREALLOC_BYTES` by default. Use this if you
   /// would rather pay for a few reallocations than let a file reserve memory
   /// it has not earned.
   pub fn with_max_prealloc(mut self, bytes: usize) -> Self {
@@ -265,10 +265,7 @@ impl FileDecompressor {
   pub fn simple_decompress<T: Number>(&self, mut src: &[u8]) -> PcoResult<Vec<T>> {
     // `n_hint` is untrusted and unrelated to how much data is actually
     // present, so we only follow it up to a cap.
-    let max_prealloc = cmp::min(
-      MAX_N_HINT_PREALLOC,
-      self.max_prealloc_bytes / mem::size_of::<T>(),
-    );
+    let max_prealloc = self.max_prealloc_bytes / mem::size_of::<T>();
     let mut res = Vec::with_capacity(cmp::min(self.n_hint(), max_prealloc));
     while let DecompressorItem::Chunk(mut chunk_decompressor) = self.chunk_decompressor(src)? {
       chunk_decompressor.decompress_remaining_extend(&mut res)?;

--- a/pco/src/standalone/decompressor.rs
+++ b/pco/src/standalone/decompressor.rs
@@ -10,7 +10,7 @@ use crate::metadata::ChunkMeta;
 use crate::progress::Progress;
 use crate::standalone::constants::*;
 use crate::wrapped;
-use std::cmp;
+use std::{cmp, mem};
 
 unsafe fn read_varint(reader: &mut BitReader) -> PcoResult<u64> {
   let power = 1 + reader.read_uint::<Bitlen>(BITS_TO_ENCODE_VARINT_POWER);
@@ -62,6 +62,7 @@ unsafe fn read_uniform_type(reader: &mut BitReader) -> PcoResult<Option<NumberTy
 pub struct FileDecompressor {
   uniform_type: Option<NumberType>,
   n_hint: usize,
+  max_prealloc_bytes: usize,
   inner: wrapped::FileDecompressor,
 }
 
@@ -129,9 +130,22 @@ impl FileDecompressor {
         inner,
         uniform_type: uniform_number_type,
         n_hint,
+        max_prealloc_bytes: usize::MAX,
       },
       rest,
     ))
+  }
+
+  /// Lowers how much memory [`Self::simple_decompress`] may preallocate based
+  /// on the file's `n_hint`.
+  ///
+  /// `n_hint` is untrusted - a tiny file may legally declare `usize::MAX` - so
+  /// it is always capped at `MAX_N_HINT_PREALLOC` numbers. Use this if you
+  /// would rather pay for a few reallocations than let a file reserve memory
+  /// it has not earned.
+  pub fn with_max_prealloc(mut self, bytes: usize) -> Self {
+    self.max_prealloc_bytes = bytes;
+    self
   }
 
   pub fn format_version(&self) -> &FormatVersion {
@@ -249,21 +263,19 @@ impl FileDecompressor {
   /// analagous file compressor method because the user always knows the dtype
   /// during compression.
   pub fn simple_decompress<T: Number>(&self, mut src: &[u8]) -> PcoResult<Vec<T>> {
-    let mut res = Vec::with_capacity(n_hint_prealloc(self.n_hint()));
+    // `n_hint` is untrusted and unrelated to how much data is actually
+    // present, so we only follow it up to a cap.
+    let max_prealloc = cmp::min(
+      MAX_N_HINT_PREALLOC,
+      self.max_prealloc_bytes / mem::size_of::<T>(),
+    );
+    let mut res = Vec::with_capacity(cmp::min(self.n_hint(), max_prealloc));
     while let DecompressorItem::Chunk(mut chunk_decompressor) = self.chunk_decompressor(src)? {
       chunk_decompressor.decompress_remaining_extend(&mut res)?;
       src = chunk_decompressor.into_src();
     }
     Ok(res)
   }
-}
-
-/// How many numbers to preallocate for a file that declares `n_hint`.
-///
-/// `n_hint` is untrusted and unrelated to how much data is actually present,
-/// so we only use it as a hint up to a fixed cap.
-pub(crate) fn n_hint_prealloc(n_hint: usize) -> usize {
-  cmp::min(n_hint, MAX_N_HINT_PREALLOC)
 }
 
 /// Holds metadata about a chunk and supports decompression.

--- a/pco/src/standalone/decompressor.rs
+++ b/pco/src/standalone/decompressor.rs
@@ -248,7 +248,11 @@ impl FileDecompressor {
   /// analagous file compressor method because the user always knows the dtype
   /// during compression.
   pub fn simple_decompress<T: Number>(&self, mut src: &[u8]) -> PcoResult<Vec<T>> {
-    let mut res = Vec::with_capacity(self.n_hint());
+    // `n_hint` is attacker-controlled and unrelated to how much data is
+    // actually present, so it may only be used as a hint up to a bound the
+    // input can actually justify. Every number costs at least one bit.
+    let cap = std::cmp::min(self.n_hint(), src.len().saturating_mul(8));
+    let mut res = Vec::with_capacity(cap);
     while let DecompressorItem::Chunk(mut chunk_decompressor) = self.chunk_decompressor(src)? {
       chunk_decompressor.decompress_remaining_extend(&mut res)?;
       src = chunk_decompressor.into_src();

--- a/pco/src/standalone/decompressor.rs
+++ b/pco/src/standalone/decompressor.rs
@@ -10,6 +10,7 @@ use crate::metadata::ChunkMeta;
 use crate::progress::Progress;
 use crate::standalone::constants::*;
 use crate::wrapped;
+use std::cmp;
 
 unsafe fn read_varint(reader: &mut BitReader) -> PcoResult<u64> {
   let power = 1 + reader.read_uint::<Bitlen>(BITS_TO_ENCODE_VARINT_POWER);
@@ -248,17 +249,21 @@ impl FileDecompressor {
   /// analagous file compressor method because the user always knows the dtype
   /// during compression.
   pub fn simple_decompress<T: Number>(&self, mut src: &[u8]) -> PcoResult<Vec<T>> {
-    // `n_hint` is attacker-controlled and unrelated to how much data is
-    // actually present, so it may only be used as a hint up to a bound the
-    // input can actually justify. Every number costs at least one bit.
-    let cap = std::cmp::min(self.n_hint(), src.len().saturating_mul(8));
-    let mut res = Vec::with_capacity(cap);
+    let mut res = Vec::with_capacity(n_hint_prealloc(self.n_hint()));
     while let DecompressorItem::Chunk(mut chunk_decompressor) = self.chunk_decompressor(src)? {
       chunk_decompressor.decompress_remaining_extend(&mut res)?;
       src = chunk_decompressor.into_src();
     }
     Ok(res)
   }
+}
+
+/// How many numbers to preallocate for a file that declares `n_hint`.
+///
+/// `n_hint` is untrusted and unrelated to how much data is actually present,
+/// so we only use it as a hint up to a fixed cap.
+pub(crate) fn n_hint_prealloc(n_hint: usize) -> usize {
+  cmp::min(n_hint, MAX_N_HINT_PREALLOC)
 }
 
 /// Holds metadata about a chunk and supports decompression.

--- a/pco/src/standalone/mod.rs
+++ b/pco/src/standalone/mod.rs
@@ -3,7 +3,7 @@ pub use decompressor::{ChunkDecompressor, DecompressorItem, FileDecompressor};
 pub use simple::*;
 
 mod compressor;
-mod constants;
-mod decompressor;
+pub(crate) mod constants;
+pub(crate) mod decompressor;
 pub mod guarantee;
 mod simple;

--- a/pco/src/standalone/mod.rs
+++ b/pco/src/standalone/mod.rs
@@ -3,7 +3,7 @@ pub use decompressor::{ChunkDecompressor, DecompressorItem, FileDecompressor};
 pub use simple::*;
 
 mod compressor;
-pub(crate) mod constants;
-pub(crate) mod decompressor;
+mod constants;
+mod decompressor;
 pub mod guarantee;
 mod simple;

--- a/pco/src/tests/corruption.rs
+++ b/pco/src/tests/corruption.rs
@@ -1,0 +1,151 @@
+//! Tests that a corrupt or hostile file is rejected rather than crashing.
+//!
+//! `stability.rs` covers *truncation*; this covers *mutation* and headers whose
+//! declared sizes are not backed by any data. Everything the decoder reads is
+//! attacker-controlled, so the contract is: return a `PcoError`, or decode to
+//! something -- but never panic, and never allocate on a number the input has
+//! not earned.
+
+use crate::chunk_config::{ChunkConfig, DeltaSpec};
+use crate::data_types::Number;
+use crate::errors::PcoResult;
+use crate::standalone::{simple_compress, simple_decompress, FileCompressor};
+use crate::ModeSpec;
+
+/// The mutations tried at each byte offset: every single-bit flip, plus the
+/// two saturating values. Cheaper than all 256 values and hits the same
+/// narrow bit fields, since the interesting header fields are 1-5 bits wide.
+fn corrupt_values(orig: u8) -> impl Iterator<Item = u8> {
+  (0..8)
+    .map(move |bit| orig ^ (1 << bit))
+    .chain([0x00, 0xff])
+    .filter(move |&v| v != orig)
+}
+
+fn configs() -> Vec<(&'static str, ChunkConfig)> {
+  vec![
+    (
+      "classic",
+      ChunkConfig::default().with_mode_spec(ModeSpec::Classic),
+    ),
+    (
+      "consecutive",
+      ChunkConfig::default().with_delta_spec(DeltaSpec::TryConsecutive(1)),
+    ),
+    (
+      "lookback",
+      ChunkConfig::default().with_delta_spec(DeltaSpec::TryLookback),
+    ),
+    (
+      "int_mult",
+      ChunkConfig::default().with_mode_spec(ModeSpec::TryIntMult(7)),
+    ),
+  ]
+}
+
+/// Every single-byte mutation of a valid file must be handled, not crash.
+///
+/// This walks every offset rather than sampling randomly: the interesting
+/// fields are a few bits wide, so a seeded sample misses them.
+#[test]
+fn test_single_byte_corruption_never_panics() -> PcoResult<()> {
+  let nums: Vec<i64> = (0..400).map(|i| (i * 3) % 97).collect();
+
+  for (name, config) in configs() {
+    let valid = simple_compress(&nums, &config)?;
+    assert!(
+      simple_decompress::<i64>(&valid)?.len() == nums.len(),
+      "{} did not round trip before corruption",
+      name
+    );
+
+    for idx in 0..valid.len() {
+      for value in corrupt_values(valid[idx]) {
+        let mut corrupt = valid.clone();
+        corrupt[idx] = value;
+        // The result is unconstrained -- corrupt data may legitimately decode
+        // to garbage -- but reaching this line at all is the assertion.
+        let _ = simple_decompress::<i64>(&corrupt);
+      }
+    }
+  }
+
+  Ok(())
+}
+
+/// Same, for float modes, which have their own latent-splitting arithmetic.
+#[test]
+fn test_single_byte_corruption_never_panics_floats() -> PcoResult<()> {
+  let nums: Vec<f64> = (0..400).map(|i| (i as f64) * 0.25).collect();
+
+  for mode_spec in [
+    ModeSpec::Classic,
+    ModeSpec::TryFloatQuant(20),
+    ModeSpec::TryFloatMult(0.25),
+  ] {
+    let config = ChunkConfig::default().with_mode_spec(mode_spec);
+    let valid = simple_compress(&nums, &config)?;
+
+    for idx in 0..valid.len() {
+      for value in corrupt_values(valid[idx]) {
+        let mut corrupt = valid.clone();
+        corrupt[idx] = value;
+        let _ = simple_decompress::<f64>(&corrupt);
+      }
+    }
+  }
+
+  Ok(())
+}
+
+/// `n_hint` is a hint, not a promise. A tiny file may declare an enormous one,
+/// so it must never be used as an allocation size on its own.
+#[test]
+fn test_absurd_n_hint_is_not_an_allocation() -> PcoResult<()> {
+  for n_hint in [1 << 20, 1 << 40, usize::MAX] {
+    let mut file = Vec::new();
+    let fc = FileCompressor::default().with_n_hint(n_hint);
+    fc.write_header(&mut file)?;
+    let mut cc = fc.chunk_compressor(&[7_i64], &ChunkConfig::default())?;
+    cc.write(&mut file)?;
+    fc.write_footer(&mut file)?;
+
+    assert!(
+      file.len() < 64,
+      "n_hint={} produced an unexpectedly large file ({} bytes)",
+      n_hint,
+      file.len()
+    );
+    assert_eq!(
+      simple_decompress::<i64>(&file)?,
+      vec![7_i64],
+      "n_hint={}",
+      n_hint
+    );
+  }
+
+  Ok(())
+}
+
+/// `FloatQuant`'s `k` is used as a shift width, so it must be rejected before
+/// any latent splitting happens -- not after.
+#[test]
+fn test_float_quant_k_beyond_type_width_is_rejected() {
+  fn check<T: Number>(k: u32, bits: u32) {
+    let config = ChunkConfig::default().with_mode_spec(ModeSpec::TryFloatQuant(k));
+    let nums = vec![T::default(); 8];
+    assert!(
+      simple_compress(&nums, &config).is_err(),
+      "k={} should be rejected for a {}-bit type",
+      k,
+      bits
+    );
+  }
+
+  for k in [64, 65, 100, 255, 256, u32::MAX] {
+    check::<f64>(k, 64);
+  }
+  for k in [32, 33, 64, 255, 256, u32::MAX] {
+    check::<f32>(k, 32);
+  }
+}

--- a/pco/src/tests/corruption.rs
+++ b/pco/src/tests/corruption.rs
@@ -9,11 +9,8 @@
 use crate::chunk_config::{ChunkConfig, DeltaSpec};
 use crate::data_types::Number;
 use crate::errors::PcoResult;
-use crate::standalone::constants::MAX_N_HINT_PREALLOC;
-use crate::standalone::decompressor::n_hint_prealloc;
-use crate::standalone::{simple_compress, simple_decompress, FileCompressor};
+use crate::standalone::{simple_compress, simple_decompress, FileCompressor, FileDecompressor};
 use crate::ModeSpec;
-use std::cmp;
 
 /// The mutations tried at each byte offset: every single-bit flip, plus the
 /// two saturating values. Cheaper than all 256 values and hits the same
@@ -25,49 +22,30 @@ fn corrupt_values(orig: u8) -> impl Iterator<Item = u8> {
     .filter(move |&v| v != orig)
 }
 
-fn configs() -> Vec<(&'static str, ChunkConfig)> {
-  vec![
-    (
-      "classic",
-      ChunkConfig::default().with_mode_spec(ModeSpec::Classic),
-    ),
-    (
-      "consecutive",
-      ChunkConfig::default().with_delta_spec(DeltaSpec::TryConsecutive(1)),
-    ),
-    (
-      "lookback",
-      ChunkConfig::default().with_delta_spec(DeltaSpec::TryLookback),
-    ),
-    (
-      "int_mult",
-      ChunkConfig::default().with_mode_spec(ModeSpec::TryIntMult(7)),
-    ),
-  ]
-}
-
-/// Every single-byte mutation of a valid file must be handled, not crash.
-///
-/// This walks every offset rather than sampling randomly: the interesting
-/// fields are a few bits wide, so a seeded sample misses them.
 #[test]
 fn test_single_byte_corruption_never_panics() -> PcoResult<()> {
   let nums: Vec<i64> = (0..400).map(|i| (i * 3) % 97).collect();
 
-  for (name, config) in configs() {
+  for config in [
+    ChunkConfig::default().with_mode_spec(ModeSpec::Classic),
+    ChunkConfig::default().with_delta_spec(DeltaSpec::TryConsecutive(1)),
+    ChunkConfig::default().with_delta_spec(DeltaSpec::TryLookback),
+    ChunkConfig::default().with_mode_spec(ModeSpec::TryIntMult(7)),
+  ] {
     let valid = simple_compress(&nums, &config)?;
-    assert!(
-      simple_decompress::<i64>(&valid)?.len() == nums.len(),
-      "{} did not round trip before corruption",
-      name
+    assert_eq!(
+      simple_decompress::<i64>(&valid)?.len(),
+      nums.len(),
+      "{:?} did not round trip before corruption",
+      config
     );
 
     for idx in 0..valid.len() {
       for value in corrupt_values(valid[idx]) {
         let mut corrupt = valid.clone();
         corrupt[idx] = value;
-        // The result is unconstrained -- corrupt data may legitimately decode
-        // to garbage -- but reaching this line at all is the assertion.
+        // Corrupt data may legitimately decode to garbage, so reaching this
+        // line at all is the assertion.
         let _ = simple_decompress::<i64>(&corrupt);
       }
     }
@@ -76,7 +54,6 @@ fn test_single_byte_corruption_never_panics() -> PcoResult<()> {
   Ok(())
 }
 
-/// Same, for float modes, which have their own latent-splitting arithmetic.
 #[test]
 fn test_single_byte_corruption_never_panics_floats() -> PcoResult<()> {
   let nums: Vec<f64> = (0..400).map(|i| (i as f64) * 0.25).collect();
@@ -101,56 +78,28 @@ fn test_single_byte_corruption_never_panics_floats() -> PcoResult<()> {
   Ok(())
 }
 
-/// `n_hint` is a hint, not a promise: a 26-byte file may legally declare
-/// `usize::MAX` (`standalone/guarantee.rs` writes exactly that), so it must be
-/// clamped before it reaches `Vec::with_capacity`.
-///
-/// This checks the clamp arithmetic rather than decompressing such a file,
-/// since the point of the clamp is that the allocation never happens.
+/// `n_hint` is a hint, not a promise: a tiny file may legally declare
+/// `usize::MAX` (`standalone/guarantee.rs` writes exactly that), so it must not
+/// reach `Vec::with_capacity` unclamped.
 #[test]
-fn test_absurd_n_hint_is_clamped() {
-  for n_hint in [0, 1 << 20, 1 << 40, usize::MAX] {
-    let capped = n_hint_prealloc(n_hint);
-    assert!(
-      capped <= MAX_N_HINT_PREALLOC,
-      "n_hint={} was not clamped ({})",
-      n_hint,
-      capped
-    );
-    assert_eq!(
-      capped,
-      cmp::min(n_hint, MAX_N_HINT_PREALLOC),
-      "n_hint={} should be preserved when small enough",
-      n_hint
-    );
-  }
-}
+fn test_absurd_n_hint_is_clamped() -> PcoResult<()> {
+  let mut file = Vec::new();
+  let fc = FileCompressor::default().with_n_hint(usize::MAX);
+  fc.write_header(&mut file)?;
+  let mut cc = fc.chunk_compressor(&[7_i64], &ChunkConfig::default())?;
+  cc.write(&mut file)?;
+  fc.write_footer(&mut file)?;
 
-/// The clamp must not disturb ordinary round trips, including for files whose
-/// `n_hint` is absurd.
-#[test]
-fn test_absurd_n_hint_still_round_trips() -> PcoResult<()> {
-  for n_hint in [1 << 20, 1 << 40, usize::MAX] {
-    let mut file = Vec::new();
-    let fc = FileCompressor::default().with_n_hint(n_hint);
-    fc.write_header(&mut file)?;
-    let mut cc = fc.chunk_compressor(&[7_i64], &ChunkConfig::default())?;
-    cc.write(&mut file)?;
-    fc.write_footer(&mut file)?;
+  let (fd, src) = FileDecompressor::new(file.as_slice())?;
+  // 8 KiB is 1024 i64s.
+  let nums = fd.with_max_prealloc(8192).simple_decompress::<i64>(src)?;
 
-    assert!(
-      file.len() < 64,
-      "n_hint={} produced an unexpectedly large file ({} bytes)",
-      n_hint,
-      file.len()
-    );
-    assert_eq!(
-      simple_decompress::<i64>(&file)?,
-      vec![7_i64],
-      "n_hint={}",
-      n_hint
-    );
-  }
+  assert_eq!(nums, vec![7_i64]);
+  assert!(
+    nums.capacity() <= 1024,
+    "preallocated {} numbers",
+    nums.capacity()
+  );
 
   Ok(())
 }

--- a/pco/src/tests/corruption.rs
+++ b/pco/src/tests/corruption.rs
@@ -9,8 +9,11 @@
 use crate::chunk_config::{ChunkConfig, DeltaSpec};
 use crate::data_types::Number;
 use crate::errors::PcoResult;
+use crate::standalone::constants::MAX_N_HINT_PREALLOC;
+use crate::standalone::decompressor::n_hint_prealloc;
 use crate::standalone::{simple_compress, simple_decompress, FileCompressor};
 use crate::ModeSpec;
+use std::cmp;
 
 /// The mutations tried at each byte offset: every single-bit flip, plus the
 /// two saturating values. Cheaper than all 256 values and hits the same
@@ -98,10 +101,35 @@ fn test_single_byte_corruption_never_panics_floats() -> PcoResult<()> {
   Ok(())
 }
 
-/// `n_hint` is a hint, not a promise. A tiny file may declare an enormous one,
-/// so it must never be used as an allocation size on its own.
+/// `n_hint` is a hint, not a promise: a 26-byte file may legally declare
+/// `usize::MAX` (`standalone/guarantee.rs` writes exactly that), so it must be
+/// clamped before it reaches `Vec::with_capacity`.
+///
+/// This checks the clamp arithmetic rather than decompressing such a file,
+/// since the point of the clamp is that the allocation never happens.
 #[test]
-fn test_absurd_n_hint_is_not_an_allocation() -> PcoResult<()> {
+fn test_absurd_n_hint_is_clamped() {
+  for n_hint in [0, 1 << 20, 1 << 40, usize::MAX] {
+    let capped = n_hint_prealloc(n_hint);
+    assert!(
+      capped <= MAX_N_HINT_PREALLOC,
+      "n_hint={} was not clamped ({})",
+      n_hint,
+      capped
+    );
+    assert_eq!(
+      capped,
+      cmp::min(n_hint, MAX_N_HINT_PREALLOC),
+      "n_hint={} should be preserved when small enough",
+      n_hint
+    );
+  }
+}
+
+/// The clamp must not disturb ordinary round trips, including for files whose
+/// `n_hint` is absurd.
+#[test]
+fn test_absurd_n_hint_still_round_trips() -> PcoResult<()> {
   for n_hint in [1 << 20, 1 << 40, usize::MAX] {
     let mut file = Vec::new();
     let fc = FileCompressor::default().with_n_hint(n_hint);

--- a/pco/src/tests/mod.rs
+++ b/pco/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod compatibility;
+mod corruption;
 mod low_level;
 mod recovery;
 mod stability;

--- a/pco/src/wrapped/chunk_compressor.rs
+++ b/pco/src/wrapped/chunk_compressor.rs
@@ -491,8 +491,6 @@ impl ChunkCompressor {
       nums,
       DynNumberSlice<T>(nums) => {
         let bid = choose_winning_bid(T::choose_mode_bids(nums, config)?);
-        // The mode must be validated before splitting: splitting can use the
-        // mode's parameters (e.g. FloatQuant's k) as shift widths.
         if !T::mode_is_valid(&bid.mode) {
           return Err(PcoError::invalid_argument(format!(
             "The chosen mode of {:?} was invalid for type {}. \

--- a/pco/src/wrapped/chunk_compressor.rs
+++ b/pco/src/wrapped/chunk_compressor.rs
@@ -2,7 +2,7 @@ use crate::bit_writer::BitWriter;
 use crate::chunk_config::DeltaSpec;
 use crate::chunk_latent_compressor::{ChunkLatentCompressor, DynChunkLatentCompressor};
 use crate::compression_intermediates::{
-  BinCompressionInfo, DissectedPage, PageInfo, PageInfoVar, TrainedBins,
+  choose_winning_bid, BinCompressionInfo, DissectedPage, PageInfo, PageInfoVar, TrainedBins,
 };
 use crate::constants::{
   Bitlen, Weight, LIMITED_UNOPTIMIZED_BINS_LOG, MAX_BATCH_LATENT_VAR_SIZE, MAX_COMPRESSION_LEVEL,
@@ -490,17 +490,20 @@ impl ChunkCompressor {
     let (mode, latents) = match_number_enum!(
       nums,
       DynNumberSlice<T>(nums) => {
-        let (mode, latents) = T::choose_mode_and_split_latents(nums, config)?;
-        if !T::mode_is_valid(&mode) {
+        let bid = choose_winning_bid(T::choose_mode_bids(nums, config)?);
+        // The mode must be validated before splitting: splitting can use the
+        // mode's parameters (e.g. FloatQuant's k) as shift widths.
+        if !T::mode_is_valid(&bid.mode) {
           return Err(PcoError::invalid_argument(format!(
             "The chosen mode of {:?} was invalid for type {}. \
             This is most likely due to an invalid argument, but if using Auto mode \
             spec, it could also be a bug in pco.",
-            mode,
+            bid.mode,
             any::type_name::<T>(),
           )));
         }
-        (mode, latents)
+        let latents = (bid.split_fn)(nums);
+        (bid.mode, latents)
       }
     );
 


### PR DESCRIPTION
Five decoder/API defects found by fuzzing and Kani, with fixes and regression tests. The harnesses that found them are now split out into #383 (fuzzing) and #382 (Kani), as requested — this PR is just the fixes and tests.

Everything below is reproducible from this branch.

## What's broken

Two of these hit stock release builds. `cargo fuzz` builds at `opt-level=3` **with** debug assertions and overflow checks, which is not what ships, so I re-checked each finding in both modes:

| # | | stock release | with overflow checks |
|---|---|---|---|
| 1 | `n_hint` → `Vec::with_capacity` | **abort / panic** | abort / panic |
| 2 | `TryFloatQuant(k)`, `k >= L::BITS` | clean `InvalidArgument` | **panic** |
| 3 | `debug_assert!` validating wire data | check absent, arithmetic wraps | **panic** |
| 4 | `mult * base` in `int_mult` | wraps (as intended) | **panic** |
| 5 | `window_n_log` → lookback window | **multi-GB allocation** | multi-GB allocation |

### 1. `n_hint` is trusted as an allocation size

`n_hint` is a varint in the standalone header (`decompressor.rs:113`). Nothing ties it to how much data is actually present — it is a hint — yet `simple_decompress` hands it straight to `Vec::with_capacity` (`decompressor.rs:251`).

* `n_hint = 2^40`, **26-byte file** → 8.8 TB allocation → process **abort**. Not a `PcoResult`; the caller cannot catch it.
* `n_hint = usize::MAX`, **34-byte file** → `capacity overflow` panic.
* Reached from **13 bytes** of unstructured input (172 GB allocation attempt).

These files come out of pco's own public API — `FileCompressor::with_n_hint`, no bit-twiddling. `standalone/guarantee.rs:56` writes `with_n_hint(usize::MAX)` in your own test suite, so it is a legal value on the write side that the read side cannot survive.

Fixed by capping the preallocation at `MAX_N_HINT_PREALLOC = 2^30` numbers.

### 2. `FloatQuant`'s `k` is used before it is validated

`data_types/float.rs:117` calls `float_quant::split_latents(nums, k)` and only *then* reaches the mode-validity check. `split_latents` does `(F::L::ONE << k) - F::L::ONE`. `TryFloatQuant(64)` on `f64` therefore shifts out of range before anything rejects it. `k = 63` is already handled correctly, so the boundary is exactly at `L::BITS`.

Fixed by ordering, not by a new check: every mode spec now emits a `Vec<Bid>`, the winner is chosen, `mode_is_valid` runs on it, and only then is `split_fn` invoked. `mode_is_valid` already rejected `k > PRECISION_BITS`.

### 3. `debug_assert!` used to validate untrusted input

`mode/float_quant.rs:26` asserts `m >> k == 0` on a latent read from the file. A **single-byte** patch of a valid 125-byte file panics on decompress in a debug build; in release the check is compiled out and `lowest_k_bits_max - m` wraps instead.

Fixed by moving the assertion to the compressor, where it belongs (it is a statement about what we emit), and making both of the decoder's arithmetic ops explicitly wrapping — corrupt `m` decodes to garbage, never panics, and costs nothing on the hot path.

### 4. `mult * base` should wrap

`mode/int_mult.rs:48` multiplies two wire-supplied latents with a plain `*`, while the addition on the same line is already `wrapping_add`. Fixed with `wrapping_mul` (added to `LatentPriv` alongside the existing `wrapping_add` / `wrapping_sub`).

### 5. The lookback window is unbounded on read

`metadata/delta_encoding.rs:155` reads `window_n_log = 1 + read_bitlen(5)`, so **1..=32**, and validates only `state_n_log <= window_n_log`. `delta/lookback.rs:192` then allocates `max(1 << window_n_log, 256) * 2` latents. The encoder never emits more than `LOOKBACK_MAX_WINDOW_N_LOG = 15` — **the decoder accepts more than the encoder can produce.**

From a valid **165-byte** lookback file:

| `window_n_log` | window buffer (i64) |
|---|---|
| 15 (encoder max) | 512 KiB |
| 24 | 256 MiB |
| 28 | 4 GiB ← what the fuzzer hit |
| 32 (format max) | 64 GiB |

Fixed with a decoder-side bound of its own, `MAX_DELTA_LOOKBACK_WINDOW_N_LOG = log2(MAX_ENTRIES) = 24` — room above what the encoder emits today, and no chunk can hold enough numbers to use a larger window anyway.

## Tests

`pco/src/tests/corruption.rs` is new: `stability.rs` covers truncation, this covers mutation. A single-byte sweep (every bit flip at every offset, over five mode/delta combinations) plus targeted tests for `n_hint`, `FloatQuant` `k`, and the lookback window bound.

**Every one of these was checked against its own fix reverted** — they all fail without the corresponding change. Suite goes 128 → 134 tests, 0.4s → 1.5s.

## One note

\#1 and #5 are remote DoS on a few bytes of input, so a public PR may not be how you'd have wanted them disclosed. Say the word and I'll close this and re-send privately.

---

A 26-byte file that requests 8.8 TB of memory is, technically, the best compression ratio in this repository. You owe me $10.
