### PR TITLE
Share calc_sample_n between mode and delta sampling

### DIFF
--- a/pco/src/data_types/float.rs
+++ b/pco/src/data_types/float.rs
@@ -89,7 +89,7 @@ fn choose_mode_bids<F: Float>(nums: &[F], chunk_config: &ChunkConfig) -> PcoResu
         split_fn: Box::new(|nums| classic::split_latents(nums)),
       }];
 
-      if let Some(sample) = sampling::choose_sample(nums, filter_sample) {
+      if let Some(sample) = sampling::choose_mode_sample(nums, filter_sample) {
         bids.extend(float_mult::compute_bid(&sample));
         bids.extend(float_quant::compute_bid(&sample));
       }

--- a/pco/src/mode/int_mult.rs
+++ b/pco/src/mode/int_mult.rs
@@ -213,7 +213,7 @@ pub fn choose_candidate_base<L: Latent>(sample: &mut [L]) -> Option<(L, f64)> {
 }
 
 pub fn choose_base<T: Number>(nums: &[T]) -> Option<T::L> {
-  let mut sample = sampling::choose_sample(nums, |num| Some(num.to_latent_ordered()))?;
+  let mut sample = sampling::choose_mode_sample(nums, |num| Some(num.to_latent_ordered()))?;
   let (candidate, bits_saved_per_adj) = choose_candidate_base(&mut sample)?;
 
   if sampling::est_bits_saved_per_num(&sample, |x| PrimaryLatentAndSavings {

--- a/pco/src/sampling.rs
+++ b/pco/src/sampling.rs
@@ -1,7 +1,8 @@
 use std::cmp::max;
 use std::collections::HashMap;
 
-use crate::constants::CLASSIC_MEMORIZABLE_BINS_LOG;
+use crate::macros::match_latent_enum;
+use crate::{constants::CLASSIC_MEMORIZABLE_BINS_LOG, metadata::DynLatents};
 use rand_xoshiro::rand_core::{RngCore, SeedableRng};
 
 use crate::data_types::Latent;
@@ -15,6 +16,7 @@ const CLASSIC_MEMORIZABLE_BINS: f64 = (1 << CLASSIC_MEMORIZABLE_BINS_LOG) as f64
 // how many times over to try collecting samples without replacement before
 // giving up
 const SAMPLING_PERSISTENCE: usize = 4;
+const DELTA_GROUP_SIZE: usize = 200;
 
 fn calc_sample_n(n: usize) -> Option<usize> {
   if n >= MIN_SAMPLE {
@@ -24,8 +26,53 @@ fn calc_sample_n(n: usize) -> Option<usize> {
   }
 }
 
+// extracted for testing
+fn choose_delta_sample_inner(
+  primary_latents: &DynLatents,
+  group_size: usize,
+  n_extra_groups: usize,
+) -> DynLatents {
+  let n = primary_latents.len();
+  let nominal_sample_size = (n_extra_groups + 1) * group_size;
+  let group_padding = if n_extra_groups == 0 {
+    0
+  } else {
+    n.saturating_sub(nominal_sample_size) / n_extra_groups
+  };
+
+  let mut i = group_size;
+
+  match_latent_enum!(
+    primary_latents,
+    DynLatents<L>(primary_latents) => {
+      let mut sample = Vec::<L>::with_capacity(nominal_sample_size);
+      sample.extend(primary_latents.iter().take(group_size));
+      for _ in 0..n_extra_groups {
+        i += group_padding;
+        sample.extend(primary_latents.iter().skip(i).take(group_size));
+        i += group_size;
+      }
+      DynLatents::new(sample)
+    }
+  )
+}
+
+pub(crate) fn choose_delta_sample(primary_latents: &DynLatents) -> Option<DynLatents> {
+  // We select some large contiguous groups of latents so that delta encodings
+  // can both sample from a variety of places in the chunk while minimizing the
+  // number of unnatural jumps.
+  let n = primary_latents.len();
+  let target_sample_n = calc_sample_n(n)?;
+  let n_extra_groups = target_sample_n / DELTA_GROUP_SIZE;
+  Some(choose_delta_sample_inner(
+    primary_latents,
+    DELTA_GROUP_SIZE,
+    n_extra_groups,
+  ))
+}
+
 #[inline(never)]
-pub fn choose_sample<T, S, Filter: Fn(&T) -> Option<S>>(
+pub fn choose_mode_sample<T, S, Filter: Fn(&T) -> Option<S>>(
   nums: &[T],
   filter: Filter,
 ) -> Option<Vec<S>> {
@@ -113,12 +160,45 @@ mod tests {
   }
 
   #[test]
-  fn test_choose_sample() {
+  fn test_choose_delta_sample() {
+    let latents = DynLatents::new(vec![0_u32, 1]);
+    assert_eq!(
+      choose_delta_sample_inner(&latents, 100, 0)
+        .downcast::<u32>()
+        .unwrap(),
+      vec![0, 1]
+    );
+    assert_eq!(
+      choose_delta_sample_inner(&latents, 100, 1)
+        .downcast::<u32>()
+        .unwrap(),
+      vec![0, 1]
+    );
+
+    let latents = DynLatents::new((0..300).collect::<Vec<u32>>());
+    let sample = choose_delta_sample_inner(&latents, 100, 1)
+      .downcast::<u32>()
+      .unwrap();
+    assert_eq!(sample.len(), 200);
+    assert_eq!(&sample[..3], &[0, 1, 2]);
+    assert_eq!(&sample[197..], &[297, 298, 299]);
+
+    let latents = DynLatents::new((0..8).collect::<Vec<u32>>());
+    assert_eq!(
+      choose_delta_sample_inner(&latents, 2, 2)
+        .downcast::<u32>()
+        .unwrap(),
+      vec![0, 1, 3, 4, 6, 7]
+    );
+  }
+
+  #[test]
+  fn test_choose_mode_sample() {
     let mut nums = Vec::new();
     for i in 0..150 {
       nums.push(-i as f32);
     }
-    let mut sample = choose_sample(&nums, |&num| {
+    let mut sample = choose_mode_sample(&nums, |&num| {
       if num == 0.0 {
         None
       } else {

--- a/pco/src/sampling.rs
+++ b/pco/src/sampling.rs
@@ -16,7 +16,7 @@ const CLASSIC_MEMORIZABLE_BINS: f64 = (1 << CLASSIC_MEMORIZABLE_BINS_LOG) as f64
 // how many times over to try collecting samples without replacement before
 // giving up
 const SAMPLING_PERSISTENCE: usize = 4;
-const DELTA_GROUP_SIZE: usize = 200;
+const DELTA_TARGET_GROUP_N: f64 = 200.0;
 
 fn calc_sample_n(n: usize) -> Option<usize> {
   if n >= MIN_SAMPLE {
@@ -29,28 +29,20 @@ fn calc_sample_n(n: usize) -> Option<usize> {
 // extracted for testing
 fn choose_delta_sample_inner(
   primary_latents: &DynLatents,
-  group_size: usize,
-  n_extra_groups: usize,
+  group_n: usize,
+  n_groups: usize,
 ) -> DynLatents {
   let n = primary_latents.len();
-  let nominal_sample_size = (n_extra_groups + 1) * group_size;
-  let group_padding = if n_extra_groups == 0 {
-    0
-  } else {
-    n.saturating_sub(nominal_sample_size) / n_extra_groups
-  };
-
-  let mut i = group_size;
+  let nominal_sample_size = n_groups * group_n;
+  let group_stride = group_n + (n.saturating_sub(nominal_sample_size) / (n_groups.max(2) - 1));
 
   match_latent_enum!(
     primary_latents,
     DynLatents<L>(primary_latents) => {
       let mut sample = Vec::<L>::with_capacity(nominal_sample_size);
-      sample.extend(primary_latents.iter().take(group_size));
-      for _ in 0..n_extra_groups {
-        i += group_padding;
-        sample.extend(primary_latents.iter().skip(i).take(group_size));
-        i += group_size;
+      for i in 0..n_groups {
+        let group_start = group_stride * i;
+        sample.extend(&primary_latents[group_start..group_start + group_n]);
       }
       DynLatents::new(sample)
     }
@@ -63,11 +55,12 @@ pub(crate) fn choose_delta_sample(primary_latents: &DynLatents) -> Option<DynLat
   // number of unnatural jumps.
   let n = primary_latents.len();
   let target_sample_n = calc_sample_n(n)?;
-  let n_extra_groups = target_sample_n / DELTA_GROUP_SIZE;
+  let n_groups = (target_sample_n as f64 / DELTA_TARGET_GROUP_N).ceil() as usize;
+  let group_n = target_sample_n / n_groups;
   Some(choose_delta_sample_inner(
     primary_latents,
-    DELTA_GROUP_SIZE,
-    n_extra_groups,
+    group_n,
+    n_groups,
   ))
 }
 
@@ -163,20 +156,20 @@ mod tests {
   fn test_choose_delta_sample() {
     let latents = DynLatents::new(vec![0_u32, 1]);
     assert_eq!(
-      choose_delta_sample_inner(&latents, 100, 0)
+      choose_delta_sample_inner(&latents, 2, 1)
         .downcast::<u32>()
         .unwrap(),
       vec![0, 1]
     );
     assert_eq!(
-      choose_delta_sample_inner(&latents, 100, 1)
+      choose_delta_sample_inner(&latents, 1, 2)
         .downcast::<u32>()
         .unwrap(),
       vec![0, 1]
     );
 
     let latents = DynLatents::new((0..300).collect::<Vec<u32>>());
-    let sample = choose_delta_sample_inner(&latents, 100, 1)
+    let sample = choose_delta_sample_inner(&latents, 100, 2)
       .downcast::<u32>()
       .unwrap();
     assert_eq!(sample.len(), 200);
@@ -185,7 +178,7 @@ mod tests {
 
     let latents = DynLatents::new((0..8).collect::<Vec<u32>>());
     assert_eq!(
-      choose_delta_sample_inner(&latents, 2, 2)
+      choose_delta_sample_inner(&latents, 2, 3)
         .downcast::<u32>()
         .unwrap(),
       vec![0, 1, 3, 4, 6, 7]

--- a/pco/src/sampling.rs
+++ b/pco/src/sampling.rs
@@ -16,7 +16,7 @@ const CLASSIC_MEMORIZABLE_BINS: f64 = (1 << CLASSIC_MEMORIZABLE_BINS_LOG) as f64
 // how many times over to try collecting samples without replacement before
 // giving up
 const SAMPLING_PERSISTENCE: usize = 4;
-const DELTA_TARGET_GROUP_N: f64 = 200.0;
+const DELTA_TARGET_GROUP_N: usize = 200;
 
 fn calc_sample_n(n: usize) -> Option<usize> {
   if n >= MIN_SAMPLE {
@@ -55,12 +55,10 @@ pub(crate) fn choose_delta_sample(primary_latents: &DynLatents) -> Option<DynLat
   // number of unnatural jumps.
   let n = primary_latents.len();
   let target_sample_n = calc_sample_n(n)?;
-  let n_groups = (target_sample_n as f64 / DELTA_TARGET_GROUP_N).ceil() as usize;
-  let group_n = target_sample_n / n_groups;
   Some(choose_delta_sample_inner(
     primary_latents,
-    group_n,
-    n_groups,
+    DELTA_TARGET_GROUP_N.min(n),
+    target_sample_n.div_ceil(DELTA_TARGET_GROUP_N),
   ))
 }
 

--- a/pco/src/wrapped/chunk_compressor.rs
+++ b/pco/src/wrapped/chunk_compressor.rs
@@ -24,7 +24,7 @@ use crate::metadata::per_latent_var::{LatentVarKey, PerLatentVar, PerLatentVarBu
 use crate::metadata::{Bin, ChunkMeta, DeltaEncoding, Mode};
 use crate::mode::classic;
 use crate::wrapped::guarantee;
-use crate::{ans, bin_optimization, delta, ChunkConfig, PagingSpec, FULL_BATCH_N};
+use crate::{ans, bin_optimization, delta, sampling, ChunkConfig, PagingSpec, FULL_BATCH_N};
 use std::any;
 use std::cmp::min;
 use std::io::Write;
@@ -32,8 +32,6 @@ use std::io::Write;
 // if it looks like the average page of size n will use k bits, hint that it
 // will be PAGE_SIZE_OVERESTIMATION * k bits.
 const PAGE_SIZE_OVERESTIMATION: f64 = 1.2;
-const N_PER_EXTRA_DELTA_GROUP: usize = 10000;
-const DELTA_GROUP_SIZE: usize = 200;
 const LOOKBACK_REQUIRED_BYTE_SAVINGS_PER_N: f32 = 0.25;
 
 // returns table size log
@@ -288,36 +286,6 @@ fn new_candidate(
   Ok((chunk_compressor, bin_countss))
 }
 
-fn choose_delta_sample(
-  primary_latents: &DynLatents,
-  group_size: usize,
-  n_extra_groups: usize,
-) -> DynLatents {
-  let n = primary_latents.len();
-  let nominal_sample_size = (n_extra_groups + 1) * group_size;
-  let group_padding = if n_extra_groups == 0 {
-    0
-  } else {
-    n.saturating_sub(nominal_sample_size) / n_extra_groups
-  };
-
-  let mut i = group_size;
-
-  match_latent_enum!(
-    primary_latents,
-    DynLatents<L>(primary_latents) => {
-      let mut sample = Vec::<L>::with_capacity(nominal_sample_size);
-      sample.extend(primary_latents.iter().take(group_size));
-      for _ in 0..n_extra_groups {
-        i += group_padding;
-        sample.extend(primary_latents.iter().skip(i).take(group_size));
-        i += group_size;
-      }
-      DynLatents::new(sample)
-    }
-  )
-}
-
 fn calculate_compressed_sample_size(
   sample: &DynLatents,
   unoptimized_bins_log: Bitlen,
@@ -343,12 +311,9 @@ fn choose_auto_delta_encoding(
   primary_latents: &DynLatents,
   unoptimized_bins_log: Bitlen,
 ) -> PcoResult<DeltaEncoding> {
-  let n = primary_latents.len();
-  let sample = choose_delta_sample(
-    primary_latents,
-    DELTA_GROUP_SIZE,
-    1 + n / N_PER_EXTRA_DELTA_GROUP,
-  );
+  let Some(sample) = sampling::choose_delta_sample(primary_latents) else {
+    return Ok(DeltaEncoding::NoOp);
+  };
   let sample_n = sample.len();
 
   let mut best_encoding = DeltaEncoding::NoOp;
@@ -737,43 +702,5 @@ impl ChunkCompressor {
     writer.finish_byte();
     writer.flush()?;
     Ok(writer.into_inner())
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn test_choose_delta_sample() {
-    let latents = DynLatents::new(vec![0_u32, 1]);
-    assert_eq!(
-      choose_delta_sample(&latents, 100, 0)
-        .downcast::<u32>()
-        .unwrap(),
-      vec![0, 1]
-    );
-    assert_eq!(
-      choose_delta_sample(&latents, 100, 1)
-        .downcast::<u32>()
-        .unwrap(),
-      vec![0, 1]
-    );
-
-    let latents = DynLatents::new((0..300).collect::<Vec<u32>>());
-    let sample = choose_delta_sample(&latents, 100, 1)
-      .downcast::<u32>()
-      .unwrap();
-    assert_eq!(sample.len(), 200);
-    assert_eq!(&sample[..3], &[0, 1, 2]);
-    assert_eq!(&sample[197..], &[297, 298, 299]);
-
-    let latents = DynLatents::new((0..8).collect::<Vec<u32>>());
-    assert_eq!(
-      choose_delta_sample(&latents, 2, 2)
-        .downcast::<u32>()
-        .unwrap(),
-      vec![0, 1, 3, 4, 6, 7]
-    );
   }
 }


### PR DESCRIPTION
* Refactored the delta sampling logic into `sampling.py`.
* Made delta sampling share `calc_sample_n` with mode sampling, slightly increasing the size of the delta sample.

Air quality dataset (heavy on delta encoding) before and after:
```
╭───────────────────────┬───────┬─────────────┬───────────────┬─────────────────╮
│ dataset               │ codec │ compress_dt │ decompress_dt │ compressed_size │
├───────────────────────┼───────┼─────────────┼───────────────┼─────────────────┤
│ i32_KafkaPartition    │ pco   │  1.204083ms │     133.458µs │              65 │
│ i64_KafkaOffset       │ pco   │  2.078083ms │     504.791µs │             113 │
│ i64_KafkaTimestamp    │ pco   │  9.954291ms │    1.665542ms │          442044 │
│ i64_timestamp         │ pco   │ 13.143375ms │    1.640708ms │         1543116 │
│ i16_pm_1              │ pco   │  4.437416ms │    1.055291ms │          116316 │
│ i16_pm_2_5            │ pco   │  4.877208ms │    1.267583ms │          133571 │
│ i16_pm_10             │ pco   │      4.88ms │      1.2595ms │          139904 │
│ i16_pm_1_atmosphere   │ pco   │  4.436333ms │    1.056209ms │          116114 │
│ i16_pm_2_5_atmosphere │ pco   │    4.8775ms │    1.273417ms │          133318 │
│ i16_pm_10_atmosphere  │ pco   │  4.885334ms │    1.258541ms │          139814 │
│ i16_p_0_3             │ pco   │  8.598375ms │    1.296083ms │          522892 │
│ i16_p_0_5             │ pco   │  7.025209ms │      1.2495ms │          500199 │
│ i16_p_1_0             │ pco   │  5.994583ms │    1.253583ms │          343949 │
│ i16_p_2_5             │ pco   │  4.943042ms │    1.265792ms │          101446 │
│ i16_p_5_0             │ pco   │  4.466708ms │    1.266208ms │           29069 │
│ i16_p_10              │ pco   │  4.469041ms │    1.271583ms │           21338 │
│ <sum>                 │ pco   │ 90.270581ms │   18.717789ms │         4283268 │
╰───────────────────────┴───────┴─────────────┴───────────────┴─────────────────╯

╭───────────────────────┬───────┬─────────────┬───────────────┬─────────────────╮
│ dataset               │ codec │ compress_dt │ decompress_dt │ compressed_size │
├───────────────────────┼───────┼─────────────┼───────────────┼─────────────────┤
│ i32_KafkaPartition    │ pco   │  1.174208ms │     135.917µs │              65 │
│ i64_KafkaOffset       │ pco   │  2.171375ms │     505.584µs │             113 │
│ i64_KafkaTimestamp    │ pco   │  9.965083ms │    1.651167ms │          442044 │
│ i64_timestamp         │ pco   │  13.28975ms │    1.650167ms │         1543116 │
│ i16_pm_1              │ pco   │  4.484416ms │    1.065917ms │          116316 │
│ i16_pm_2_5            │ pco   │  4.950417ms │    1.270292ms │          133571 │
│ i16_pm_10             │ pco   │  4.965167ms │    1.266875ms │          139904 │
│ i16_pm_1_atmosphere   │ pco   │  4.480625ms │     1.05975ms │          116114 │
│ i16_pm_2_5_atmosphere │ pco   │  4.938458ms │    1.267667ms │          133318 │
│ i16_pm_10_atmosphere  │ pco   │     4.949ms │    1.270292ms │          139814 │
│ i16_p_0_3             │ pco   │     8.694ms │    1.298833ms │          522892 │
│ i16_p_0_5             │ pco   │  7.103208ms │    1.265875ms │          500199 │
│ i16_p_1_0             │ pco   │  6.061875ms │    1.259959ms │          343949 │
│ i16_p_2_5             │ pco   │  5.000333ms │    1.265916ms │          101446 │
│ i16_p_5_0             │ pco   │   4.46775ms │    1.272584ms │           29069 │
│ i16_p_10              │ pco   │    4.4605ms │    1.276875ms │           21338 │
│ <sum>                 │ pco   │ 91.156165ms │    18.78367ms │         4283268 │
╰───────────────────────┴───────┴─────────────┴───────────────┴─────────────────╯
```