### PR TITLE
Use Floyd's algorithm for mode sampling

### DIFF
--- a/pco/src/data_types/float.rs
+++ b/pco/src/data_types/float.rs
@@ -459,7 +459,7 @@ mod tests {
   #[test]
   fn test_choose_mult_mode() {
     let base = 1.5;
-    let nums = (0..1000).map(|i| (i as f64) * base).collect::<Vec<_>>();
+    let nums = (0..2000).map(|i| (i as f64) * base).collect::<Vec<_>>();
     let mode = choose_mode(&nums);
     assert_eq!(mode, Mode::float_mult(base));
     assert!(f64::mode_is_valid(&mode))

--- a/pco/src/sampling.rs
+++ b/pco/src/sampling.rs
@@ -13,9 +13,6 @@ const SAMPLE_RATIO: usize = 40;
 // Int mults will be considered infrequent if they occur less than 1/this of
 // the time.
 const CLASSIC_MEMORIZABLE_BINS: f64 = (1 << CLASSIC_MEMORIZABLE_BINS_LOG) as f64;
-// how many times over to try collecting samples without replacement before
-// giving up
-const SAMPLING_PERSISTENCE: usize = 4;
 const DELTA_TARGET_GROUP_N: usize = 200;
 
 fn calc_sample_n(n: usize) -> Option<usize> {
@@ -62,35 +59,37 @@ pub(crate) fn choose_delta_sample(primary_latents: &DynLatents) -> Option<DynLat
   ))
 }
 
+#[inline]
+fn is_visited(visited: &[u8], idx: usize) -> bool {
+  visited[idx / 8] & (1 << (idx % 8)) != 0
+}
+
+#[inline]
+fn mark_visited(visited: &mut [u8], idx: usize) {
+  visited[idx / 8] |= 1 << (idx % 8);
+}
+
 #[inline(never)]
 pub fn choose_mode_sample<T, S, Filter: Fn(&T) -> Option<S>>(
   nums: &[T],
   filter: Filter,
 ) -> Option<Vec<S>> {
-  // We can't modify the list, and copying it may be expensive, but we want to
-  // sample a small fraction from it without replacement, so we keep a
-  // bitpacked vector representing whether each one is used yet and just keep
-  // resampling.
-  // Maybe this is a bad idea, but it works for now.
-  let target_sample_size = calc_sample_n(nums.len())?;
+  // We use Floyd's algorithm to draw a sample without replacement or modifying
+  // nums. One nice property is that if we take a larger sample, it will begin
+  // with the same subset as a smaller sample, keeping noise manageable.
+  let n = nums.len();
+  let target_sample_n = calc_sample_n(n)?;
 
   let mut rng = rand_xoshiro::Xoroshiro128PlusPlus::seed_from_u64(0);
-  let mut visited = vec![0_u8; nums.len().div_ceil(8)];
-  let mut res = Vec::with_capacity(target_sample_size);
-  let mut n_iters = 0;
-  while res.len() < target_sample_size && n_iters < SAMPLING_PERSISTENCE * target_sample_size {
-    let rand_idx = rng.next_u64() as usize % nums.len();
-    let visited_idx = rand_idx / 8;
-    let visited_bit = rand_idx % 8;
-    let mask = 1 << visited_bit;
-    let is_visited = visited[visited_idx] & mask;
-    if is_visited == 0 {
-      if let Some(x) = filter(&nums[rand_idx]) {
-        res.push(x);
-      }
-      visited[visited_idx] |= mask;
+  let mut visited = vec![0_u8; n.div_ceil(8)];
+  let mut res = Vec::with_capacity(target_sample_n);
+  for j in (n - target_sample_n)..n {
+    let t = (rng.next_u64() % (j as u64 + 1)) as usize;
+    let idx = if is_visited(&visited, t) { j } else { t };
+    mark_visited(&mut visited, idx);
+    if let Some(x) = filter(&nums[idx]) {
+      res.push(x);
     }
-    n_iters += 1;
   }
 
   if res.len() >= MIN_SAMPLE {
@@ -199,6 +198,6 @@ mod tests {
     .unwrap();
     sample.sort_unstable_by(f32::total_cmp);
     assert_eq!(sample.len(), 13);
-    assert_eq!(&sample[0..3], &[-147.0, -142.0, -119.0]);
+    assert_eq!(&sample[0..3], &[-135.0, -131.0, -114.0]);
   }
 }


### PR DESCRIPTION
This is slightly simpler and guarantees we select the number of values we desire, rather than just being likely to.

On taxi dataset, before and after:
```
│ <sum>                    │ pco   │ 4.313934209s │           0ns │       333568673 │

│ <sum>                    │ pco   │ 4.277558461s │           0ns │       333337220 │
```